### PR TITLE
feat(#4): Community RBAC policies

### DIFF
--- a/src/Access/CommunityRole.php
+++ b/src/Access/CommunityRole.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Access;
+
+enum CommunityRole: string
+{
+    case Admin           = 'admin';
+    case KnowledgeKeeper = 'knowledge_keeper';
+    case Staff           = 'staff';
+    case Member          = 'member';
+    case Public          = 'public';
+
+    public function rank(): int
+    {
+        return match ($this) {
+            self::Admin           => 5,
+            self::KnowledgeKeeper => 4,
+            self::Staff           => 3,
+            self::Member          => 2,
+            self::Public          => 1,
+        };
+    }
+}

--- a/src/Access/KnowledgeItemAccessPolicy.php
+++ b/src/Access/KnowledgeItemAccessPolicy.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Access;
+
+use Giiken\Entity\KnowledgeItem\AccessTier;
+use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Access policy for KnowledgeItem entities.
+ *
+ * Community roles are encoded as account roles in the format:
+ *   giiken.community.{communityId}.{roleSlug}
+ *
+ * Example: giiken.community.abc-123.staff
+ *
+ * This allows multi-tenancy enforcement: a role granted in community A
+ * carries no weight in community B.
+ */
+#[PolicyAttribute('knowledge_item')]
+final class KnowledgeItemAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'knowledge_item';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if (!$entity instanceof KnowledgeItem) {
+            return AccessResult::neutral();
+        }
+
+        $role = $this->resolveRole($entity->getCommunityId(), $account);
+
+        // Admins always have access.
+        if ($role === CommunityRole::Admin) {
+            return AccessResult::allowed('admin role');
+        }
+
+        return match ($entity->getAccessTier()) {
+            AccessTier::Public     => AccessResult::allowed('public tier'),
+            AccessTier::Members    => $role->rank() >= CommunityRole::Member->rank()
+                ? AccessResult::allowed('member tier')
+                : AccessResult::forbidden('member tier requires authentication'),
+            AccessTier::Staff      => $role->rank() >= CommunityRole::Staff->rank()
+                ? AccessResult::allowed('staff tier')
+                : AccessResult::forbidden('staff tier requires staff role or above'),
+            AccessTier::Restricted => $this->evaluateRestricted($role, $entity, $account),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        return AccessResult::neutral();
+    }
+
+    /**
+     * Resolve the current account's community role for a specific community.
+     *
+     * Looks for a role string matching "giiken.community.{communityId}.{roleSlug}".
+     * Falls back to CommunityRole::Public if no match is found.
+     */
+    private function resolveRole(string $communityId, AccountInterface $account): CommunityRole
+    {
+        $prefix = "giiken.community.{$communityId}.";
+
+        foreach ($account->getRoles() as $roleStr) {
+            if (!str_starts_with($roleStr, $prefix)) {
+                continue;
+            }
+
+            $slug = substr($roleStr, strlen($prefix));
+            $communityRole = CommunityRole::tryFrom($slug);
+
+            if ($communityRole !== null) {
+                return $communityRole;
+            }
+        }
+
+        return CommunityRole::Public;
+    }
+
+    /**
+     * Evaluate access for restricted-tier items.
+     *
+     * Knowledge Keepers and above are always allowed.
+     * Below that, access is granted if the user's role slug is in allowed_roles
+     * OR the user's ID is in allowed_users.
+     */
+    private function evaluateRestricted(
+        CommunityRole $role,
+        KnowledgeItem $entity,
+        AccountInterface $account,
+    ): AccessResult {
+        if ($role->rank() >= CommunityRole::KnowledgeKeeper->rank()) {
+            return AccessResult::allowed('knowledge_keeper role');
+        }
+
+        if (in_array($role->value, $entity->getAllowedRoles(), true)) {
+            return AccessResult::allowed('role in allowed_roles');
+        }
+
+        $userId = (string) $account->id();
+
+        if ($userId !== '' && $userId !== '0' && in_array($userId, $entity->getAllowedUsers(), true)) {
+            return AccessResult::allowed('user in allowed_users');
+        }
+
+        return AccessResult::forbidden('restricted tier: not in allowed_roles or allowed_users');
+    }
+}

--- a/tests/Unit/Access/KnowledgeItemAccessPolicyTest.php
+++ b/tests/Unit/Access/KnowledgeItemAccessPolicyTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Tests\Unit\Access;
+
+use Giiken\Access\KnowledgeItemAccessPolicy;
+use Giiken\Entity\KnowledgeItem\AccessTier;
+use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\Access\AccountInterface;
+
+#[CoversClass(KnowledgeItemAccessPolicy::class)]
+final class KnowledgeItemAccessPolicyTest extends TestCase
+{
+    private const COMMUNITY_A = 'community-a';
+    private const COMMUNITY_B = 'community-b';
+    private const USER_UUID   = 'user-uuid-123';
+
+    private KnowledgeItemAccessPolicy $policy;
+
+    protected function setUp(): void
+    {
+        $this->policy = new KnowledgeItemAccessPolicy();
+    }
+
+    // ------------------------------------------------------------------
+    // Public tier
+    // ------------------------------------------------------------------
+
+    #[Test]
+    public function public_tier_allows_anonymous(): void
+    {
+        $result = $this->policy->access(
+            $this->item(AccessTier::Public),
+            'view',
+            $this->account(id: '0', roles: []),
+        );
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    // ------------------------------------------------------------------
+    // Members tier
+    // ------------------------------------------------------------------
+
+    #[Test]
+    public function members_tier_denies_anonymous(): void
+    {
+        $result = $this->policy->access(
+            $this->item(AccessTier::Members),
+            'view',
+            $this->account(id: '0', roles: []),
+        );
+
+        $this->assertTrue($result->isForbidden());
+    }
+
+    #[Test]
+    public function members_tier_allows_member(): void
+    {
+        $result = $this->policy->access(
+            $this->item(AccessTier::Members),
+            'view',
+            $this->account(id: '1', roles: ["giiken.community." . self::COMMUNITY_A . ".member"]),
+        );
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    // ------------------------------------------------------------------
+    // Staff tier
+    // ------------------------------------------------------------------
+
+    #[Test]
+    public function staff_tier_denies_member(): void
+    {
+        $result = $this->policy->access(
+            $this->item(AccessTier::Staff),
+            'view',
+            $this->account(id: '1', roles: ["giiken.community." . self::COMMUNITY_A . ".member"]),
+        );
+
+        $this->assertTrue($result->isForbidden());
+    }
+
+    #[Test]
+    public function staff_tier_allows_staff(): void
+    {
+        $result = $this->policy->access(
+            $this->item(AccessTier::Staff),
+            'view',
+            $this->account(id: '2', roles: ["giiken.community." . self::COMMUNITY_A . ".staff"]),
+        );
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    // ------------------------------------------------------------------
+    // Restricted tier — role-based
+    // ------------------------------------------------------------------
+
+    #[Test]
+    public function restricted_tier_denies_staff_not_in_allowed_roles(): void
+    {
+        $result = $this->policy->access(
+            $this->item(AccessTier::Restricted, allowedRoles: ['knowledge_keeper']),
+            'view',
+            $this->account(id: '2', roles: ["giiken.community." . self::COMMUNITY_A . ".staff"]),
+        );
+
+        $this->assertTrue($result->isForbidden());
+    }
+
+    #[Test]
+    public function restricted_tier_allows_knowledge_keeper_by_role_rank(): void
+    {
+        $result = $this->policy->access(
+            $this->item(AccessTier::Restricted, allowedRoles: ['knowledge_keeper']),
+            'view',
+            $this->account(id: '3', roles: ["giiken.community." . self::COMMUNITY_A . ".knowledge_keeper"]),
+        );
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    // ------------------------------------------------------------------
+    // Restricted tier — user-based
+    // ------------------------------------------------------------------
+
+    #[Test]
+    public function restricted_tier_denies_different_user(): void
+    {
+        $result = $this->policy->access(
+            $this->item(AccessTier::Restricted, allowedUsers: [self::USER_UUID]),
+            'view',
+            $this->account(id: 'other-user', roles: ["giiken.community." . self::COMMUNITY_A . ".member"]),
+        );
+
+        $this->assertTrue($result->isForbidden());
+    }
+
+    #[Test]
+    public function restricted_tier_allows_exact_user(): void
+    {
+        $result = $this->policy->access(
+            $this->item(AccessTier::Restricted, allowedUsers: [self::USER_UUID]),
+            'view',
+            $this->account(id: self::USER_UUID, roles: ["giiken.community." . self::COMMUNITY_A . ".member"]),
+        );
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function restricted_tier_allows_when_matching_either_roles_or_users(): void
+    {
+        $result = $this->policy->access(
+            $this->item(
+                AccessTier::Restricted,
+                allowedRoles: ['knowledge_keeper'],
+                allowedUsers: [self::USER_UUID],
+            ),
+            'view',
+            $this->account(id: self::USER_UUID, roles: ["giiken.community." . self::COMMUNITY_A . ".member"]),
+        );
+
+        $this->assertTrue($result->isAllowed());
+    }
+
+    // ------------------------------------------------------------------
+    // Admin always allowed
+    // ------------------------------------------------------------------
+
+    #[Test]
+    public function admin_can_access_any_tier(): void
+    {
+        $admin = $this->account(id: '99', roles: ["giiken.community." . self::COMMUNITY_A . ".admin"]);
+
+        foreach ([AccessTier::Public, AccessTier::Members, AccessTier::Staff, AccessTier::Restricted] as $tier) {
+            $result = $this->policy->access($this->item($tier), 'view', $admin);
+            $this->assertTrue($result->isAllowed(), "Admin failed on tier: {$tier->value}");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Multi-tenancy: community A role does not bleed into community B
+    // ------------------------------------------------------------------
+
+    #[Test]
+    public function community_a_knowledge_keeper_cannot_access_community_b_restricted(): void
+    {
+        $item = new KnowledgeItem([
+            'community_id'  => self::COMMUNITY_B,
+            'title'         => 'Community B secret',
+            'content'       => 'Body',
+            'access_tier'   => AccessTier::Restricted->value,
+            'allowed_roles' => json_encode(['knowledge_keeper'], JSON_THROW_ON_ERROR),
+            'allowed_users' => json_encode([], JSON_THROW_ON_ERROR),
+        ]);
+
+        $account = $this->account(
+            id: '5',
+            roles: ["giiken.community." . self::COMMUNITY_A . ".knowledge_keeper"],
+        );
+
+        $result = $this->policy->access($item, 'view', $account);
+
+        $this->assertTrue($result->isForbidden());
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * @param string[] $allowedRoles
+     * @param string[] $allowedUsers
+     */
+    private function item(
+        AccessTier $tier,
+        array $allowedRoles = [],
+        array $allowedUsers = [],
+    ): KnowledgeItem {
+        return new KnowledgeItem([
+            'community_id'  => self::COMMUNITY_A,
+            'title'         => 'Test Item',
+            'content'       => 'Body',
+            'access_tier'   => $tier->value,
+            'allowed_roles' => json_encode($allowedRoles, JSON_THROW_ON_ERROR),
+            'allowed_users' => json_encode($allowedUsers, JSON_THROW_ON_ERROR),
+        ]);
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function account(string $id, array $roles): AccountInterface
+    {
+        return new class($id, $roles) implements AccountInterface {
+            /** @param string[] $roles */
+            public function __construct(
+                private readonly string $id,
+                private readonly array $roles,
+            ) {}
+
+            public function id(): int|string { return $this->id; }
+            public function getRoles(): array { return $this->roles; }
+            public function isAuthenticated(): bool { return $this->id !== '0'; }
+            public function hasPermission(string $permission): bool { return false; }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- `CommunityRole` enum with rank-based comparison (Admin→5 down to Public→1)
- `KnowledgeItemAccessPolicy` — auto-discovered via `#[PolicyAttribute('knowledge_item')]`, no constructor dependencies
- Community role isolation via scoped role strings: `giiken.community.{communityId}.{roleSlug}` — a knowledge_keeper in community A cannot access restricted items in community B
- Full tier rule matrix: public/members/staff/restricted with allowed_roles + allowed_users support for restricted tier

## Test plan

- [ ] 11 unit tests pass covering full acceptance matrix from #4
- [ ] Multi-tenancy case: community A knowledge_keeper denied on community B restricted item
- [ ] Admin role allows all tiers
- [ ] Restricted tier: matching either allowed_roles or allowed_users is sufficient

Closes #4