### PR TITLE
chore: Waaseyaa alpha alignment, templates, and SSR DX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Environment variables for your Waaseyaa application.
+#
+# This file is committed to version control as a template.
+# Copy to .env.local for personal overrides (never committed).
+#
+# Precedence: process env > .env.local > .env
+
+# -- Application ----------------------------------------------------------------
+APP_NAME=Giiken
+APP_ENV=local
+APP_DEBUG=true
+APP_URL=http://localhost:8080
+
+# Minimum log level: debug | info | notice | warning | error | critical | alert | emergency
+# LOG_LEVEL=warning
+
+# -- Database -------------------------------------------------------------------
+WAASEYAA_DB=./storage/waaseyaa.sqlite
+
+# -- Authentication --------------------------------------------------------------
+# Generate and set this for non-local environments.
+WAASEYAA_JWT_SECRET=
+
+# -- CORS -----------------------------------------------------------------------
+# Allowed origin for the admin SPA. Defaults to http://localhost:3000.
+# WAASEYAA_CORS_ORIGIN=http://localhost:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Path-resolve waaseyaa/foundation from monorepo until Packagist has a tag with Http\Inbound types.
+      # After the framework PR lands on default branch, set ref to that branch (e.g. main).
+      - uses: actions/checkout@v4
+        with:
+          repository: waaseyaa/framework
+          ref: claude/ssr-app-name-render-fallback-20260409
+          path: waaseyaa-framework
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -18,7 +26,10 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: |
+          composer install --no-interaction --prefer-dist
+          composer config repositories.foundation-local path waaseyaa-framework/packages/foundation
+          composer update waaseyaa/foundation --no-interaction
 
       - name: Check lifecycle documentation drift
         run: ./scripts/check-lifecycle-drift.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
 
+      - name: Check lifecycle documentation drift
+        run: ./scripts/check-lifecycle-drift.sh
+
       - name: Run PHPUnit
         run: ./vendor/bin/phpunit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # lifecycle-drift uses git diff origin/${BASE_REF}...HEAD; shallow clones have no merge base.
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Path-resolve waaseyaa/foundation from monorepo until Packagist has a tag with Http\Inbound types.
-      # After the framework PR lands on default branch, set ref to that branch (e.g. main).
-      - uses: actions/checkout@v4
-        with:
-          repository: waaseyaa/framework
-          ref: claude/ssr-app-name-render-fallback-20260409
-          path: waaseyaa-framework
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -26,10 +18,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: |
-          composer install --no-interaction --prefer-dist
-          composer config repositories.foundation-local path waaseyaa-framework/packages/foundation
-          composer update waaseyaa/foundation --no-interaction
+        run: composer install --no-interaction --prefer-dist
 
       - name: Check lifecycle documentation drift
         run: ./scripts/check-lifecycle-drift.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /vendor/
+.env
+.env.local
 /.phpunit.cache/
 /phpstan/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,16 @@
 /vendor/
+/storage/framework/
+/files/*
+!/files/.gitkeep
+*.sqlite
 .env
+
+# Giiken — not shipped in skeleton (Node/Vite, caches, local storage root, tool scratch)
 .env.local
 /.phpunit.cache/
 /phpstan/
-
-# Node / frontend
 /node_modules/
 /node-compile-cache/
 /public/build/
-
-# Local runtime
 /storage/
-
-# Background sync tool stray working dirs
 /waaseyaa-sync-*/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,14 @@ Giiken is a sovereign indigenous knowledge management platform built on the **Wa
 3. 🟡 **EntityRepository factory** — waaseyaa/framework#1128. The framework provides no `EntityTypeManager::getRepository(string $id)` accessor. Building a working `Waaseyaa\EntityStorage\EntityRepository` requires manually assembling 3-7 dependencies. This is the architectural blocker for #42 below.
 4. 🟡 **Hook discipline** — waaseyaa/framework#1126 (spec-drift + phpunit pre-push hooks) is the meta-blocker for cutting alpha.108.
 
+### Upgrade note (2026-04-09)
+
+- Giiken dependency lock is now on the current Waaseyaa alpha line (`v0.1.0-alpha.113` for most packages; `waaseyaa/core` at `v0.1.0-alpha.110`).
+- `waaseyaa/ssr` had to be re-added as an explicit app dependency to satisfy `Waaseyaa\User\UserServiceProvider` runtime wiring after `composer update "waaseyaa/*"`.
+- `public/index.php` now emits responses (`$response = $kernel->handle(); $response->send();`) to avoid zero-byte `200` responses.
+- Unit and full PHPUnit suites pass after updating controller/test signatures for the current SSR app-controller calling convention (`($params, $query, $account, $httpRequest)`).
+- Current runtime blocker: `GET /{community-slug}` still returns `500` (`<h1>Internal Server Error</h1>`) under `php -S`, despite dependency and signature fixes. This requires follow-up debugging in SSR dispatch/runtime error reporting.
+
 ### Giiken-side prerequisites (this repo)
 
 5. 🔴 **Service registrations** — #42, blocked on framework#1128. `GiikenServiceProvider::register()` does not bind `SearchService`, `QaServiceInterface`, `CommunityRepositoryInterface`, or `KnowledgeItemRepositoryInterface`. `SsrPageHandler::resolveControllerInstance()` throws when reflecting `DiscoveryController`'s constructor. Wiring requires `EntityRepository` factory machinery that doesn't exist yet.
@@ -37,6 +45,14 @@ Giiken is a sovereign indigenous knowledge management platform built on the **Wa
 # Dependencies
 composer install
 
+# Common scripts
+composer run dev
+composer run test
+composer run analyse
+
+# Install git hooks
+lefthook install
+
 # Run all tests
 ./vendor/bin/phpunit
 
@@ -48,6 +64,10 @@ composer install
 
 # Static analysis
 ./vendor/bin/phpstan analyse src/
+
+# Run hooks manually
+lefthook run pre-commit
+lefthook run pre-push
 ```
 
 ## Architecture
@@ -114,6 +134,12 @@ Built-in checks: `BrokenLinkCheck`, `OrphanPageCheck`.
 ### Service Provider
 
 `GiikenServiceProvider` registers entity types with `EntityTypeManager` and defines routes via `WaaseyaaRouter`. This is the entry point for adding new entity types or wiring new ingestion handlers.
+
+### Lifecycle Documentation Governance
+
+- Canonical runtime flow doc: `docs/architecture/lifecycle.md`
+- CI enforces drift checks via `scripts/check-lifecycle-drift.sh`
+- If lifecycle-impacting files change (`public/index.php`, `src/GiikenServiceProvider.php`, HTTP controllers/middleware, entities/query/pipeline code), update `docs/architecture/lifecycle.md` in the same PR.
 
 ## Testing Conventions
 

--- a/bin/waaseyaa
+++ b/bin/waaseyaa
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$projectRoot = dirname(__DIR__);
+
+if (class_exists(\Symfony\Component\Dotenv\Dotenv::class)) {
+    try {
+        (new \Symfony\Component\Dotenv\Dotenv())->loadEnv($projectRoot . '/.env');
+    } catch (\Symfony\Component\Dotenv\Exception\FormatException|\Symfony\Component\Dotenv\Exception\PathException $e) {
+        fwrite(STDERR, 'Error: Failed to load .env: ' . $e->getMessage() . "\n");
+        fwrite(STDERR, "Check your .env, .env.local, and environment-specific .env files for syntax errors.\n");
+        exit(1);
+    }
+}
+
+$kernel = new Waaseyaa\Foundation\Kernel\ConsoleKernel($projectRoot);
+exit($kernel->handle());

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=8.4",
+        "symfony/dotenv": "^7.4",
         "symfony/yaml": "^7.4",
         "waaseyaa/access": "^0.1",
         "waaseyaa/admin-surface": "^0.1",
@@ -31,6 +32,7 @@
         "waaseyaa/queue": "^0.1",
         "waaseyaa/routing": "^0.1",
         "waaseyaa/search": "^0.1",
+        "waaseyaa/ssr": "^0.1",
         "waaseyaa/state": "^0.1",
         "waaseyaa/taxonomy": "^0.1",
         "waaseyaa/testing": "^0.1",
@@ -47,6 +49,11 @@
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true
+    },
+    "scripts": {
+        "analyse": "./vendor/bin/phpstan analyse src tests --level=8 --no-progress",
+        "dev": "php bin/waaseyaa serve",
+        "test": "./vendor/bin/phpunit"
     },
     "extra": {
         "waaseyaa": {

--- a/composer.lock
+++ b/composer.lock
@@ -4495,7 +4495,7 @@
         },
         {
             "name": "waaseyaa/access",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/access.git",
@@ -4537,13 +4537,13 @@
             "description": "Access control and permission system for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/access/issues",
-                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/admin-surface",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/admin-surface.git",
@@ -4591,13 +4591,13 @@
             "description": "Canonical integration boundary for the Waaseyaa Admin SPA",
             "support": {
                 "issues": "https://github.com/waaseyaa/admin-surface/issues",
-                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-09T00:23:33+00:00"
         },
         {
             "name": "waaseyaa/ai-agent",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-agent.git",
@@ -4636,13 +4636,13 @@
             "description": "AI agent orchestration and tool execution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-agent/issues",
-                "source": "https://github.com/waaseyaa/ai-agent/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/ai-agent/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/ai-pipeline",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-pipeline.git",
@@ -4687,13 +4687,13 @@
             "description": "AI processing pipelines with queue-based execution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-pipeline/issues",
-                "source": "https://github.com/waaseyaa/ai-pipeline/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/ai-pipeline/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/ai-schema",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-schema.git",
@@ -4731,13 +4731,13 @@
             "description": "AI-friendly schema definitions and entity metadata for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-schema/issues",
-                "source": "https://github.com/waaseyaa/ai-schema/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/ai-schema/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/ai-vector",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-vector.git",
@@ -4779,13 +4779,13 @@
             "description": "Vector embedding storage and similarity search for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-vector/issues",
-                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/api",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/api.git",
@@ -4832,13 +4832,13 @@
             "description": "RESTful JSON:API resource layer for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/api/issues",
-                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-09T02:45:12+00:00"
         },
         {
             "name": "waaseyaa/auth",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/auth.git",
@@ -4883,13 +4883,13 @@
             "description": "Headless authentication for Waaseyaa — login, registration, 2FA, password reset",
             "support": {
                 "issues": "https://github.com/waaseyaa/auth/issues",
-                "source": "https://github.com/waaseyaa/auth/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/auth/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T18:25:20+00:00"
         },
         {
             "name": "waaseyaa/cache",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cache.git",
@@ -4932,13 +4932,13 @@
             "description": "Cache bins with cache tag invalidation for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cache/issues",
-                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/cli",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cli.git",
@@ -4989,13 +4989,13 @@
             "description": "Command-line interface and console commands for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cli/issues",
-                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/config",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/config.git",
@@ -5034,13 +5034,13 @@
             "description": "Configuration management as YAML with package-aware ownership for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/config/issues",
-                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/core",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/core.git",
@@ -5090,13 +5090,13 @@
             "description": "Waaseyaa core engine — entities, fields, config, plugins, routing, access.",
             "support": {
                 "issues": "https://github.com/waaseyaa/core/issues",
-                "source": "https://github.com/waaseyaa/core/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/core/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-09T14:32:41+00:00"
         },
         {
             "name": "waaseyaa/database-legacy",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/database-legacy.git",
@@ -5134,13 +5134,13 @@
             "description": "Database adapter wrapping Drupal DBAL. Interim until Doctrine migration.",
             "support": {
                 "issues": "https://github.com/waaseyaa/database-legacy/issues",
-                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/entity",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity.git",
@@ -5186,13 +5186,13 @@
             "description": "Entity type system — types, interfaces, lifecycle, queries. No storage.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity/issues",
-                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-09T03:10:30+00:00"
         },
         {
             "name": "waaseyaa/entity-storage",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity-storage.git",
@@ -5234,13 +5234,13 @@
             "description": "Pluggable entity persistence. v0.1.0: SQL storage behind clean interfaces.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity-storage/issues",
-                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-09T13:06:20+00:00"
         },
         {
             "name": "waaseyaa/error-handler",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/error-handler.git",
@@ -5283,13 +5283,13 @@
             "description": "Rich exception pages, solution hints, and editor links for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/error-handler/issues",
-                "source": "https://github.com/waaseyaa/error-handler/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/error-handler/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T18:25:20+00:00"
         },
         {
             "name": "waaseyaa/field",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/field.git",
@@ -5329,22 +5329,22 @@
             "description": "Field type system — pluggable field types, definitions, formatters for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/field/issues",
-                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/foundation",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/foundation.git",
-                "reference": "b2b7ddbd3fc70d34a48ee009af05f8283832233c"
+                "reference": "ae0b5b71298f051dd18496ddbc67c5683cd89885"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/b2b7ddbd3fc70d34a48ee009af05f8283832233c",
-                "reference": "b2b7ddbd3fc70d34a48ee009af05f8283832233c",
+                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/ae0b5b71298f051dd18496ddbc67c5683cd89885",
+                "reference": "ae0b5b71298f051dd18496ddbc67c5683cd89885",
                 "shasum": ""
             },
             "require": {
@@ -5385,13 +5385,13 @@
             "description": "Core framework primitives: service providers, domain events, results, error handling",
             "support": {
                 "issues": "https://github.com/waaseyaa/foundation/issues",
-                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.115"
             },
-            "time": "2026-04-09T03:10:30+00:00"
+            "time": "2026-04-09T16:18:03+00:00"
         },
         {
             "name": "waaseyaa/i18n",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/i18n.git",
@@ -5429,13 +5429,13 @@
             "description": "Internationalization foundation: Language, LanguageManager, LanguageContext, FallbackChain",
             "support": {
                 "issues": "https://github.com/waaseyaa/i18n/issues",
-                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/inertia",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/inertia.git",
@@ -5478,13 +5478,13 @@
             "description": "Server-side Inertia.js v3 protocol adapter for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/inertia/issues",
-                "source": "https://github.com/waaseyaa/inertia/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/inertia/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T16:57:28+00:00"
         },
         {
             "name": "waaseyaa/ingestion",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ingestion.git",
@@ -5523,13 +5523,13 @@
             "description": "Payload validation and ingestion utilities for Waaseyaa applications",
             "support": {
                 "issues": "https://github.com/waaseyaa/ingestion/issues",
-                "source": "https://github.com/waaseyaa/ingestion/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/ingestion/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/mail",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/mail.git",
@@ -5577,13 +5577,13 @@
             "description": "Transport-agnostic mail API for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/mail/issues",
-                "source": "https://github.com/waaseyaa/mail/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/mail/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-09T02:22:27+00:00"
         },
         {
             "name": "waaseyaa/media",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/media.git",
@@ -5630,13 +5630,13 @@
             "description": "Media entity type and file management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/media/issues",
-                "source": "https://github.com/waaseyaa/media/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/media/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T16:57:28+00:00"
         },
         {
             "name": "waaseyaa/plugin",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/plugin.git",
@@ -5674,13 +5674,13 @@
             "description": "Attribute-based plugin discovery and management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/plugin/issues",
-                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/queue",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/queue.git",
@@ -5725,13 +5725,13 @@
             "description": "Asynchronous task queue and job processing for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/queue/issues",
-                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/relationship",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/relationship.git",
@@ -5773,13 +5773,13 @@
             "description": "Reusable relationship primitives for Waaseyaa applications",
             "support": {
                 "issues": "https://github.com/waaseyaa/relationship/issues",
-                "source": "https://github.com/waaseyaa/relationship/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/relationship/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-09T03:10:30+00:00"
         },
         {
             "name": "waaseyaa/routing",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/routing.git",
@@ -5820,13 +5820,13 @@
             "description": "HTTP routing and controller resolution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/routing/issues",
-                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/search",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/search.git",
@@ -5873,22 +5873,22 @@
             "description": "Search provider interface and DTOs for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/search/issues",
-                "source": "https://github.com/waaseyaa/search/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/search/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/ssr",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ssr.git",
-                "reference": "d225a19a249b5cea86a5dba45c5b7ebc7d0a3e83"
+                "reference": "b8cf3a47bcf6410a60e1628d561dd14ae62709ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/ssr/zipball/d225a19a249b5cea86a5dba45c5b7ebc7d0a3e83",
-                "reference": "d225a19a249b5cea86a5dba45c5b7ebc7d0a3e83",
+                "url": "https://api.github.com/repos/waaseyaa/ssr/zipball/b8cf3a47bcf6410a60e1628d561dd14ae62709ed",
+                "reference": "b8cf3a47bcf6410a60e1628d561dd14ae62709ed",
                 "shasum": ""
             },
             "require": {
@@ -5932,13 +5932,13 @@
             "description": "Server-side rendering with Twig templates for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ssr/issues",
-                "source": "https://github.com/waaseyaa/ssr/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/ssr/tree/v0.1.0-alpha.115"
             },
-            "time": "2026-04-09T02:36:46+00:00"
+            "time": "2026-04-09T16:18:03+00:00"
         },
         {
             "name": "waaseyaa/state",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/state.git",
@@ -5976,13 +5976,13 @@
             "description": "Key-value state storage for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/state/issues",
-                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/taxonomy",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/taxonomy.git",
@@ -6026,13 +6026,13 @@
             "description": "Taxonomy vocabulary and term entity types for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/taxonomy/issues",
-                "source": "https://github.com/waaseyaa/taxonomy/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/taxonomy/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/testing",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/testing.git",
@@ -6068,13 +6068,13 @@
             "description": "Testing utilities for Waaseyaa — base test case, entity factories, and helper traits.",
             "support": {
                 "issues": "https://github.com/waaseyaa/testing/issues",
-                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/typed-data",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/typed-data.git",
@@ -6112,13 +6112,13 @@
             "description": "Type system with PHP-native facade for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/typed-data/issues",
-                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/user",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/user.git",
@@ -6166,13 +6166,13 @@
             "description": "User entity, authentication, and session management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/user/issues",
-                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-09T02:22:27+00:00"
         },
         {
             "name": "waaseyaa/validation",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/validation.git",
@@ -6211,13 +6211,13 @@
             "description": "Data validation constraints and validators for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/validation/issues",
-                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/workflows",
-            "version": "v0.1.0-alpha.114",
+            "version": "v0.1.0-alpha.115",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/workflows.git",
@@ -6262,7 +6262,7 @@
             "description": "Content moderation and editorial workflow states for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/workflows/issues",
-                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.114"
+                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.115"
             },
             "time": "2026-04-08T15:25:48+00:00"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aad85df6710099ad148367600a6507a8",
+    "content-hash": "ba60a6c8e039cc60ad369f860ec66f9d",
     "packages": [
         {
             "name": "doctrine/dbal",
@@ -159,6 +159,188 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
             "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "league/uri",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "URN",
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc2141",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "rfc8141",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-15T20:22:25+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1025,6 +1207,114 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "psr/log",
@@ -2407,6 +2697,84 @@
             "time": "2024-09-25T14:21:43+00:00"
         },
         {
+            "name": "symfony/dotenv",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dotenv.git",
+                "reference": "5df79f11350166125fe754c85b87f7e13d735314"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/5df79f11350166125fe754c85b87f7e13d735314",
+                "reference": "5df79f11350166125fe754c85b87f7e13d735314",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "conflict": {
+                "symfony/console": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Dotenv\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Registers environment variables from a .env file",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/dotenv/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T12:55:43+00:00"
+        },
+        {
             "name": "symfony/event-dispatcher",
             "version": "v7.4.8",
             "source": {
@@ -2566,6 +2934,78 @@
                 }
             ],
             "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/html-sanitizer",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/html-sanitizer.git",
+                "reference": "b0e4a2d9a82ab6bdcc742a63398781f6dae64fe5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/b0e4a2d9a82ab6bdcc742a63398781f6dae64fe5",
+                "reference": "b0e4a2d9a82ab6bdcc742a63398781f6dae64fe5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "league/uri": "^6.5|^7.0",
+                "php": ">=8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HtmlSanitizer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Titouan Galopin",
+                    "email": "galopintitouan@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to sanitize untrusted HTML input for safe insertion into a document's DOM.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "Purifier",
+                "html",
+                "sanitizer"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/html-sanitizer/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -4055,16 +4495,16 @@
         },
         {
             "name": "waaseyaa/access",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/access.git",
-                "reference": "058806755f61dca5170fc7a5b9f5ba87c3a19b91"
+                "reference": "1b00f385ad6bf66a9fe5cc90c16d620b0f3f2976"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/access/zipball/058806755f61dca5170fc7a5b9f5ba87c3a19b91",
-                "reference": "058806755f61dca5170fc7a5b9f5ba87c3a19b91",
+                "url": "https://api.github.com/repos/waaseyaa/access/zipball/1b00f385ad6bf66a9fe5cc90c16d620b0f3f2976",
+                "reference": "1b00f385ad6bf66a9fe5cc90c16d620b0f3f2976",
                 "shasum": ""
             },
             "require": {
@@ -4097,31 +4537,32 @@
             "description": "Access control and permission system for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/access/issues",
-                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T00:46:26+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/admin-surface",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/admin-surface.git",
-                "reference": "2b8f267b6bee93358649e1ab87ff378dfc477025"
+                "reference": "50cd0b2ea13545e065b88fe94f57a84fc17285dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/admin-surface/zipball/2b8f267b6bee93358649e1ab87ff378dfc477025",
-                "reference": "2b8f267b6bee93358649e1ab87ff378dfc477025",
+                "url": "https://api.github.com/repos/waaseyaa/admin-surface/zipball/50cd0b2ea13545e065b88fe94f57a84fc17285dc",
+                "reference": "50cd0b2ea13545e065b88fe94f57a84fc17285dc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "waaseyaa/access": "@dev",
-                "waaseyaa/api": "@dev",
-                "waaseyaa/entity": "@dev",
-                "waaseyaa/foundation": "@dev",
-                "waaseyaa/routing": "@dev"
+                "symfony/http-foundation": "^7.0",
+                "waaseyaa/access": "^0.1",
+                "waaseyaa/api": "^0.1",
+                "waaseyaa/entity": "^0.1",
+                "waaseyaa/foundation": "^0.1",
+                "waaseyaa/routing": "^0.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -4150,22 +4591,22 @@
             "description": "Canonical integration boundary for the Waaseyaa Admin SPA",
             "support": {
                 "issues": "https://github.com/waaseyaa/admin-surface/issues",
-                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-02T15:57:27+00:00"
+            "time": "2026-04-09T00:23:33+00:00"
         },
         {
             "name": "waaseyaa/ai-agent",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-agent.git",
-                "reference": "41f3f31dca6aa3d55e0e7ab677fdceb56f3a87e1"
+                "reference": "a9a816394d712e0ffb996657f630858682fc658e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/ai-agent/zipball/41f3f31dca6aa3d55e0e7ab677fdceb56f3a87e1",
-                "reference": "41f3f31dca6aa3d55e0e7ab677fdceb56f3a87e1",
+                "url": "https://api.github.com/repos/waaseyaa/ai-agent/zipball/a9a816394d712e0ffb996657f630858682fc658e",
+                "reference": "a9a816394d712e0ffb996657f630858682fc658e",
                 "shasum": ""
             },
             "require": {
@@ -4195,22 +4636,22 @@
             "description": "AI agent orchestration and tool execution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-agent/issues",
-                "source": "https://github.com/waaseyaa/ai-agent/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/ai-agent/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-23T06:24:45+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/ai-pipeline",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-pipeline.git",
-                "reference": "b3ae04f083295ae6a197b570ead64f35865c93e2"
+                "reference": "509a4234f50163163f160eec21e141ec08daecbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/ai-pipeline/zipball/b3ae04f083295ae6a197b570ead64f35865c93e2",
-                "reference": "b3ae04f083295ae6a197b570ead64f35865c93e2",
+                "url": "https://api.github.com/repos/waaseyaa/ai-pipeline/zipball/509a4234f50163163f160eec21e141ec08daecbc",
+                "reference": "509a4234f50163163f160eec21e141ec08daecbc",
                 "shasum": ""
             },
             "require": {
@@ -4246,22 +4687,22 @@
             "description": "AI processing pipelines with queue-based execution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-pipeline/issues",
-                "source": "https://github.com/waaseyaa/ai-pipeline/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/ai-pipeline/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-29T16:26:20+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/ai-schema",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-schema.git",
-                "reference": "cb7bf171d71a8eb5ceeb339e1a135b7182410a75"
+                "reference": "facef4d312db8254083a59655a6ce232aaa28dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/ai-schema/zipball/cb7bf171d71a8eb5ceeb339e1a135b7182410a75",
-                "reference": "cb7bf171d71a8eb5ceeb339e1a135b7182410a75",
+                "url": "https://api.github.com/repos/waaseyaa/ai-schema/zipball/facef4d312db8254083a59655a6ce232aaa28dc6",
+                "reference": "facef4d312db8254083a59655a6ce232aaa28dc6",
                 "shasum": ""
             },
             "require": {
@@ -4290,22 +4731,22 @@
             "description": "AI-friendly schema definitions and entity metadata for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-schema/issues",
-                "source": "https://github.com/waaseyaa/ai-schema/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/ai-schema/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-23T06:34:58+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/ai-vector",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-vector.git",
-                "reference": "bcd4a78798435feaabdbb3dc6023588a5d2f9482"
+                "reference": "73ef3177bfdc457591eab9cf876955d06b01644f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/ai-vector/zipball/bcd4a78798435feaabdbb3dc6023588a5d2f9482",
-                "reference": "bcd4a78798435feaabdbb3dc6023588a5d2f9482",
+                "url": "https://api.github.com/repos/waaseyaa/ai-vector/zipball/73ef3177bfdc457591eab9cf876955d06b01644f",
+                "reference": "73ef3177bfdc457591eab9cf876955d06b01644f",
                 "shasum": ""
             },
             "require": {
@@ -4338,22 +4779,22 @@
             "description": "Vector embedding storage and similarity search for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-vector/issues",
-                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-03T14:58:04+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/api",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/api.git",
-                "reference": "aeaec471e380182cdf504c9ab291a0dd725c87e3"
+                "reference": "b1740253a1482758ec6df63a8985db358a99a3d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/api/zipball/aeaec471e380182cdf504c9ab291a0dd725c87e3",
-                "reference": "aeaec471e380182cdf504c9ab291a0dd725c87e3",
+                "url": "https://api.github.com/repos/waaseyaa/api/zipball/b1740253a1482758ec6df63a8985db358a99a3d0",
+                "reference": "b1740253a1482758ec6df63a8985db358a99a3d0",
                 "shasum": ""
             },
             "require": {
@@ -4361,11 +4802,11 @@
                 "waaseyaa/access": "^0.1",
                 "waaseyaa/entity": "^0.1",
                 "waaseyaa/foundation": "^0.1",
-                "waaseyaa/routing": "^0.1",
-                "waaseyaa/ssr": "^0.1"
+                "waaseyaa/routing": "^0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^10.5",
+                "waaseyaa/database-legacy": "^0.1"
             },
             "type": "library",
             "extra": {
@@ -4391,29 +4832,29 @@
             "description": "RESTful JSON:API resource layer for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/api/issues",
-                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-01T17:53:50+00:00"
+            "time": "2026-04-09T02:45:12+00:00"
         },
         {
             "name": "waaseyaa/auth",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/auth.git",
-                "reference": "740cafbcbc66db1d3f64adc011b64450c59aed01"
+                "reference": "c10ecd1352d73867da7fb46c6de7013e321566bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/auth/zipball/740cafbcbc66db1d3f64adc011b64450c59aed01",
-                "reference": "740cafbcbc66db1d3f64adc011b64450c59aed01",
+                "url": "https://api.github.com/repos/waaseyaa/auth/zipball/c10ecd1352d73867da7fb46c6de7013e321566bb",
+                "reference": "c10ecd1352d73867da7fb46c6de7013e321566bb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "waaseyaa/foundation": "@dev",
-                "waaseyaa/mail": "@dev",
-                "waaseyaa/user": "@dev"
+                "waaseyaa/foundation": "^0.1",
+                "waaseyaa/mail": "^0.1",
+                "waaseyaa/user": "^0.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -4442,22 +4883,22 @@
             "description": "Headless authentication for Waaseyaa — login, registration, 2FA, password reset",
             "support": {
                 "issues": "https://github.com/waaseyaa/auth/issues",
-                "source": "https://github.com/waaseyaa/auth/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/auth/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T00:46:26+00:00"
+            "time": "2026-04-08T18:25:20+00:00"
         },
         {
             "name": "waaseyaa/cache",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cache.git",
-                "reference": "3237b4b6460f1b70499c50e788d3995570aa60f8"
+                "reference": "c2517edfb8029f5268508e35cc51f85e643b6b41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/cache/zipball/3237b4b6460f1b70499c50e788d3995570aa60f8",
-                "reference": "3237b4b6460f1b70499c50e788d3995570aa60f8",
+                "url": "https://api.github.com/repos/waaseyaa/cache/zipball/c2517edfb8029f5268508e35cc51f85e643b6b41",
+                "reference": "c2517edfb8029f5268508e35cc51f85e643b6b41",
                 "shasum": ""
             },
             "require": {
@@ -4491,22 +4932,22 @@
             "description": "Cache bins with cache tag invalidation for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cache/issues",
-                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-23T00:58:08+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/cli",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cli.git",
-                "reference": "414a783ba0872ac12a55aab398e06f6030b653c3"
+                "reference": "aae4ec784f3bb7834c03e6f7200d2c7246025624"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/cli/zipball/414a783ba0872ac12a55aab398e06f6030b653c3",
-                "reference": "414a783ba0872ac12a55aab398e06f6030b653c3",
+                "url": "https://api.github.com/repos/waaseyaa/cli/zipball/aae4ec784f3bb7834c03e6f7200d2c7246025624",
+                "reference": "aae4ec784f3bb7834c03e6f7200d2c7246025624",
                 "shasum": ""
             },
             "require": {
@@ -4521,6 +4962,9 @@
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
             },
+            "bin": [
+                "bin/waaseyaa"
+            ],
             "type": "library",
             "extra": {
                 "waaseyaa": {
@@ -4545,22 +4989,22 @@
             "description": "Command-line interface and console commands for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cli/issues",
-                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T00:46:26+00:00"
+            "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/config",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/config.git",
-                "reference": "8c1b12e530feb63317b7993f12e12209f27d8d4a"
+                "reference": "22976a335ea478a18a98d25569c656b7710ca0dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/config/zipball/8c1b12e530feb63317b7993f12e12209f27d8d4a",
-                "reference": "8c1b12e530feb63317b7993f12e12209f27d8d4a",
+                "url": "https://api.github.com/repos/waaseyaa/config/zipball/22976a335ea478a18a98d25569c656b7710ca0dc",
+                "reference": "22976a335ea478a18a98d25569c656b7710ca0dc",
                 "shasum": ""
             },
             "require": {
@@ -4590,22 +5034,22 @@
             "description": "Configuration management as YAML with package-aware ownership for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/config/issues",
-                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-02T16:14:37+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/core",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/core.git",
-                "reference": "22d1f54bdbe86ce30ee15f44f4ed9977808e3ff2"
+                "reference": "55f41c2555e0c081bc9fcf01f4d3071998d63fcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/core/zipball/22d1f54bdbe86ce30ee15f44f4ed9977808e3ff2",
-                "reference": "22d1f54bdbe86ce30ee15f44f4ed9977808e3ff2",
+                "url": "https://api.github.com/repos/waaseyaa/core/zipball/55f41c2555e0c081bc9fcf01f4d3071998d63fcc",
+                "reference": "55f41c2555e0c081bc9fcf01f4d3071998d63fcc",
                 "shasum": ""
             },
             "require": {
@@ -4615,6 +5059,7 @@
                 "waaseyaa/database-legacy": "^0.1",
                 "waaseyaa/entity": "^0.1",
                 "waaseyaa/entity-storage": "^0.1",
+                "waaseyaa/error-handler": "^0.1",
                 "waaseyaa/field": "^0.1",
                 "waaseyaa/foundation": "^0.1",
                 "waaseyaa/i18n": "^0.1",
@@ -4622,11 +5067,14 @@
                 "waaseyaa/queue": "^0.1",
                 "waaseyaa/routing": "^0.1",
                 "waaseyaa/state": "^0.1",
-                "waaseyaa/telescope": "^0.1",
-                "waaseyaa/testing": "^0.1",
                 "waaseyaa/typed-data": "^0.1",
                 "waaseyaa/user": "^0.1",
                 "waaseyaa/validation": "^0.1"
+            },
+            "suggest": {
+                "waaseyaa/debug": "Enable dev-only debug helpers and toolbar integration.",
+                "waaseyaa/telescope": "Enable runtime observability dashboards and inspection tooling.",
+                "waaseyaa/testing": "Install in-memory testing fixtures and framework test helpers."
             },
             "type": "metapackage",
             "extra": {
@@ -4642,22 +5090,22 @@
             "description": "Waaseyaa core engine — entities, fields, config, plugins, routing, access.",
             "support": {
                 "issues": "https://github.com/waaseyaa/core/issues",
-                "source": "https://github.com/waaseyaa/core/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/core/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-16T21:50:01+00:00"
+            "time": "2026-04-09T14:32:41+00:00"
         },
         {
             "name": "waaseyaa/database-legacy",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/database-legacy.git",
-                "reference": "a480ed7777cde0d0530fc3069fe21c6cff0eaea7"
+                "reference": "84f79677f698638b075510f1bf1dbe8c5aa91cba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/database-legacy/zipball/a480ed7777cde0d0530fc3069fe21c6cff0eaea7",
-                "reference": "a480ed7777cde0d0530fc3069fe21c6cff0eaea7",
+                "url": "https://api.github.com/repos/waaseyaa/database-legacy/zipball/84f79677f698638b075510f1bf1dbe8c5aa91cba",
+                "reference": "84f79677f698638b075510f1bf1dbe8c5aa91cba",
                 "shasum": ""
             },
             "require": {
@@ -4686,29 +5134,29 @@
             "description": "Database adapter wrapping Drupal DBAL. Interim until Doctrine migration.",
             "support": {
                 "issues": "https://github.com/waaseyaa/database-legacy/issues",
-                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-19T22:48:53+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/entity",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity.git",
-                "reference": "8f2f3f5d5050b1a3c744aa4b5ad144784a99aea2"
+                "reference": "6e06c085a8c04b422ba1aad4976c74ac417cf555"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/entity/zipball/8f2f3f5d5050b1a3c744aa4b5ad144784a99aea2",
-                "reference": "8f2f3f5d5050b1a3c744aa4b5ad144784a99aea2",
+                "url": "https://api.github.com/repos/waaseyaa/entity/zipball/6e06c085a8c04b422ba1aad4976c74ac417cf555",
+                "reference": "6e06c085a8c04b422ba1aad4976c74ac417cf555",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "symfony/event-dispatcher": "^7.3",
-                "symfony/uid": "^7.3",
-                "symfony/validator": "^7.3",
+                "symfony/event-dispatcher": "^7.0",
+                "symfony/uid": "^7.0",
+                "symfony/validator": "^7.0",
                 "waaseyaa/cache": "^0.1",
                 "waaseyaa/config": "^0.1",
                 "waaseyaa/foundation": "^0.1",
@@ -4738,27 +5186,27 @@
             "description": "Entity type system — types, interfaces, lifecycle, queries. No storage.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity/issues",
-                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T17:16:03+00:00"
+            "time": "2026-04-09T03:10:30+00:00"
         },
         {
             "name": "waaseyaa/entity-storage",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity-storage.git",
-                "reference": "8bee09b09e3711ed807eb75241b26b9b6ce03ed7"
+                "reference": "8caa1bed3f8cd66e8cee7191a345d0d7eeb5acb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/entity-storage/zipball/8bee09b09e3711ed807eb75241b26b9b6ce03ed7",
-                "reference": "8bee09b09e3711ed807eb75241b26b9b6ce03ed7",
+                "url": "https://api.github.com/repos/waaseyaa/entity-storage/zipball/8caa1bed3f8cd66e8cee7191a345d0d7eeb5acb9",
+                "reference": "8caa1bed3f8cd66e8cee7191a345d0d7eeb5acb9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "symfony/event-dispatcher": "^7.3",
+                "symfony/event-dispatcher": "^7.0",
                 "waaseyaa/cache": "^0.1",
                 "waaseyaa/database-legacy": "^0.1",
                 "waaseyaa/entity": "^0.1",
@@ -4786,22 +5234,71 @@
             "description": "Pluggable entity persistence. v0.1.0: SQL storage behind clean interfaces.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity-storage/issues",
-                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T17:16:03+00:00"
+            "time": "2026-04-09T13:06:20+00:00"
         },
         {
-            "name": "waaseyaa/field",
-            "version": "v0.1.0-alpha.104",
+            "name": "waaseyaa/error-handler",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
-                "url": "https://github.com/waaseyaa/field.git",
-                "reference": "628d19b0bddd68d24a0d49e70f6525cc24d6dbbb"
+                "url": "https://github.com/waaseyaa/error-handler.git",
+                "reference": "aee47db65b79dd02160af17cc8619f9f08b15dfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/field/zipball/628d19b0bddd68d24a0d49e70f6525cc24d6dbbb",
-                "reference": "628d19b0bddd68d24a0d49e70f6525cc24d6dbbb",
+                "url": "https://api.github.com/repos/waaseyaa/error-handler/zipball/aee47db65b79dd02160af17cc8619f9f08b15dfd",
+                "reference": "aee47db65b79dd02160af17cc8619f9f08b15dfd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "waaseyaa/foundation": "^0.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "waaseyaa": {
+                    "providers": [
+                        "Waaseyaa\\ErrorHandler\\ErrorHandlerServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "0.1.x-dev",
+                    "dev-develop/v1.1": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Waaseyaa\\ErrorHandler\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Rich exception pages, solution hints, and editor links for Waaseyaa",
+            "support": {
+                "issues": "https://github.com/waaseyaa/error-handler/issues",
+                "source": "https://github.com/waaseyaa/error-handler/tree/v0.1.0-alpha.114"
+            },
+            "time": "2026-04-08T18:25:20+00:00"
+        },
+        {
+            "name": "waaseyaa/field",
+            "version": "v0.1.0-alpha.114",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/waaseyaa/field.git",
+                "reference": "73ad0e23cf9f923bdb03e25b7cb9999f6ec72c84"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/waaseyaa/field/zipball/73ad0e23cf9f923bdb03e25b7cb9999f6ec72c84",
+                "reference": "73ad0e23cf9f923bdb03e25b7cb9999f6ec72c84",
                 "shasum": ""
             },
             "require": {
@@ -4832,22 +5329,22 @@
             "description": "Field type system — pluggable field types, definitions, formatters for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/field/issues",
-                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T00:46:26+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/foundation",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/foundation.git",
-                "reference": "f9f6933233b1971193642537a0981d94217d7500"
+                "reference": "b2b7ddbd3fc70d34a48ee009af05f8283832233c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/f9f6933233b1971193642537a0981d94217d7500",
-                "reference": "f9f6933233b1971193642537a0981d94217d7500",
+                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/b2b7ddbd3fc70d34a48ee009af05f8283832233c",
+                "reference": "b2b7ddbd3fc70d34a48ee009af05f8283832233c",
                 "shasum": ""
             },
             "require": {
@@ -4861,7 +5358,8 @@
                 "waaseyaa/queue": "^0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^10.5",
+                "waaseyaa/error-handler": "^0.1"
             },
             "type": "library",
             "extra": {
@@ -4887,22 +5385,22 @@
             "description": "Core framework primitives: service providers, domain events, results, error handling",
             "support": {
                 "issues": "https://github.com/waaseyaa/foundation/issues",
-                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T17:16:03+00:00"
+            "time": "2026-04-09T03:10:30+00:00"
         },
         {
             "name": "waaseyaa/i18n",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/i18n.git",
-                "reference": "98d4b59c71022c7d588fa0d5a4b6df6f10251b8c"
+                "reference": "ed47e9eb95922394fda9bef51e945875a4a9ce5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/i18n/zipball/98d4b59c71022c7d588fa0d5a4b6df6f10251b8c",
-                "reference": "98d4b59c71022c7d588fa0d5a4b6df6f10251b8c",
+                "url": "https://api.github.com/repos/waaseyaa/i18n/zipball/ed47e9eb95922394fda9bef51e945875a4a9ce5d",
+                "reference": "ed47e9eb95922394fda9bef51e945875a4a9ce5d",
                 "shasum": ""
             },
             "require": {
@@ -4931,27 +5429,27 @@
             "description": "Internationalization foundation: Language, LanguageManager, LanguageContext, FallbackChain",
             "support": {
                 "issues": "https://github.com/waaseyaa/i18n/issues",
-                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-16T21:50:01+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/inertia",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/inertia.git",
-                "reference": "e30ebcc1acddcd788ade550ca00466f5c04edb54"
+                "reference": "14a42ad153a6e78a9ebf301d3f9d72269c09d323"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/inertia/zipball/e30ebcc1acddcd788ade550ca00466f5c04edb54",
-                "reference": "e30ebcc1acddcd788ade550ca00466f5c04edb54",
+                "url": "https://api.github.com/repos/waaseyaa/inertia/zipball/14a42ad153a6e78a9ebf301d3f9d72269c09d323",
+                "reference": "14a42ad153a6e78a9ebf301d3f9d72269c09d323",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "waaseyaa/foundation": "@dev"
+                "waaseyaa/foundation": "^0.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -4980,22 +5478,22 @@
             "description": "Server-side Inertia.js v3 protocol adapter for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/inertia/issues",
-                "source": "https://github.com/waaseyaa/inertia/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/inertia/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-23T17:30:12+00:00"
+            "time": "2026-04-08T16:57:28+00:00"
         },
         {
             "name": "waaseyaa/ingestion",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ingestion.git",
-                "reference": "9a861f620ff032f8852ac7640c5bc4eab22d8ab5"
+                "reference": "706923cc27b0b9c4b8f08d24ed07433fa07a4d60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/ingestion/zipball/9a861f620ff032f8852ac7640c5bc4eab22d8ab5",
-                "reference": "9a861f620ff032f8852ac7640c5bc4eab22d8ab5",
+                "url": "https://api.github.com/repos/waaseyaa/ingestion/zipball/706923cc27b0b9c4b8f08d24ed07433fa07a4d60",
+                "reference": "706923cc27b0b9c4b8f08d24ed07433fa07a4d60",
                 "shasum": ""
             },
             "require": {
@@ -5025,22 +5523,22 @@
             "description": "Payload validation and ingestion utilities for Waaseyaa applications",
             "support": {
                 "issues": "https://github.com/waaseyaa/ingestion/issues",
-                "source": "https://github.com/waaseyaa/ingestion/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/ingestion/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T00:46:26+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/mail",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/mail.git",
-                "reference": "05b8e3e1f41bd6e6a6e193a1c470309580e3a6d9"
+                "reference": "2359fb9f94817e4b0f7c791700b4df19325a92aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/mail/zipball/05b8e3e1f41bd6e6a6e193a1c470309580e3a6d9",
-                "reference": "05b8e3e1f41bd6e6a6e193a1c470309580e3a6d9",
+                "url": "https://api.github.com/repos/waaseyaa/mail/zipball/2359fb9f94817e4b0f7c791700b4df19325a92aa",
+                "reference": "2359fb9f94817e4b0f7c791700b4df19325a92aa",
                 "shasum": ""
             },
             "require": {
@@ -5052,7 +5550,7 @@
                 "twig/twig": "^3.0"
             },
             "suggest": {
-                "sendgrid/sendgrid": "Required for SendGridDriver mail transport (^8.1)",
+                "sendgrid/sendgrid": "Required for SendGrid API transport when using mail.sendgrid_api_key (^8.1)",
                 "twig/twig": "Required for TwigMailRenderer template support"
             },
             "type": "library",
@@ -5079,30 +5577,34 @@
             "description": "Transport-agnostic mail API for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/mail/issues",
-                "source": "https://github.com/waaseyaa/mail/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/mail/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T00:46:26+00:00"
+            "time": "2026-04-09T02:22:27+00:00"
         },
         {
             "name": "waaseyaa/media",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/media.git",
-                "reference": "3551ed355bf583848067785293830c0f243ded1a"
+                "reference": "e9a3ffa7d97dc0dc24056c26365077f1d4c42eda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/media/zipball/3551ed355bf583848067785293830c0f243ded1a",
-                "reference": "3551ed355bf583848067785293830c0f243ded1a",
+                "url": "https://api.github.com/repos/waaseyaa/media/zipball/e9a3ffa7d97dc0dc24056c26365077f1d4c42eda",
+                "reference": "e9a3ffa7d97dc0dc24056c26365077f1d4c42eda",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "waaseyaa/entity": "^0.1"
+                "waaseyaa/entity": "^0.1",
+                "waaseyaa/foundation": "^0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^10.5",
+                "waaseyaa/access": "^0.1",
+                "waaseyaa/api": "^0.1",
+                "waaseyaa/database-legacy": "^0.1"
             },
             "type": "library",
             "extra": {
@@ -5128,27 +5630,27 @@
             "description": "Media entity type and file management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/media/issues",
-                "source": "https://github.com/waaseyaa/media/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/media/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-30T16:26:08+00:00"
+            "time": "2026-04-08T16:57:28+00:00"
         },
         {
             "name": "waaseyaa/plugin",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/plugin.git",
-                "reference": "cdcf6140eaba74e2be53b0c58927542099a1e936"
+                "reference": "cf5589b780d4ac87a05ab289e7b6cec9ca3113d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/plugin/zipball/cdcf6140eaba74e2be53b0c58927542099a1e936",
-                "reference": "cdcf6140eaba74e2be53b0c58927542099a1e936",
+                "url": "https://api.github.com/repos/waaseyaa/plugin/zipball/cf5589b780d4ac87a05ab289e7b6cec9ca3113d4",
+                "reference": "cf5589b780d4ac87a05ab289e7b6cec9ca3113d4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "waaseyaa/cache": "*"
+                "waaseyaa/cache": "^0.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -5172,27 +5674,27 @@
             "description": "Attribute-based plugin discovery and management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/plugin/issues",
-                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T00:46:26+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/queue",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/queue.git",
-                "reference": "0bd4b8e560fcba724dfb359f7bcb50c7e87141bc"
+                "reference": "1745f5fb5efc3efa0c3364dc2c49f3024847d489"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/queue/zipball/0bd4b8e560fcba724dfb359f7bcb50c7e87141bc",
-                "reference": "0bd4b8e560fcba724dfb359f7bcb50c7e87141bc",
+                "url": "https://api.github.com/repos/waaseyaa/queue/zipball/1745f5fb5efc3efa0c3364dc2c49f3024847d489",
+                "reference": "1745f5fb5efc3efa0c3364dc2c49f3024847d489",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "symfony/messenger": "^7.3",
+                "symfony/messenger": "^7.0",
                 "waaseyaa/database-legacy": "^0.1",
                 "waaseyaa/foundation": "^0.1"
             },
@@ -5223,22 +5725,22 @@
             "description": "Asynchronous task queue and job processing for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/queue/issues",
-                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T00:46:26+00:00"
+            "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/relationship",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/relationship.git",
-                "reference": "e2ba48bcce57ee31e2efbe43c882e9c88ae44976"
+                "reference": "b3e2b168fc7e880e7eeb5c9dcb60bf82ef74910d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/relationship/zipball/e2ba48bcce57ee31e2efbe43c882e9c88ae44976",
-                "reference": "e2ba48bcce57ee31e2efbe43c882e9c88ae44976",
+                "url": "https://api.github.com/repos/waaseyaa/relationship/zipball/b3e2b168fc7e880e7eeb5c9dcb60bf82ef74910d",
+                "reference": "b3e2b168fc7e880e7eeb5c9dcb60bf82ef74910d",
                 "shasum": ""
             },
             "require": {
@@ -5271,27 +5773,27 @@
             "description": "Reusable relationship primitives for Waaseyaa applications",
             "support": {
                 "issues": "https://github.com/waaseyaa/relationship/issues",
-                "source": "https://github.com/waaseyaa/relationship/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/relationship/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-30T16:26:08+00:00"
+            "time": "2026-04-09T03:10:30+00:00"
         },
         {
             "name": "waaseyaa/routing",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/routing.git",
-                "reference": "7765323e93fec85620250d300fffc7b0adce8961"
+                "reference": "b2ccc82b514f081bb83f43932b79baac3f5b45ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/routing/zipball/7765323e93fec85620250d300fffc7b0adce8961",
-                "reference": "7765323e93fec85620250d300fffc7b0adce8961",
+                "url": "https://api.github.com/repos/waaseyaa/routing/zipball/b2ccc82b514f081bb83f43932b79baac3f5b45ce",
+                "reference": "b2ccc82b514f081bb83f43932b79baac3f5b45ce",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "symfony/routing": "^7.3",
+                "symfony/routing": "^7.0",
                 "waaseyaa/access": "^0.1",
                 "waaseyaa/entity": "^0.1",
                 "waaseyaa/i18n": "^0.1"
@@ -5318,31 +5820,31 @@
             "description": "HTTP routing and controller resolution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/routing/issues",
-                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-23T17:30:12+00:00"
+            "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/search",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/search.git",
-                "reference": "28d6377306b3fe8ca6f46eafe63518ddde35bbc1"
+                "reference": "41ec53d24211442d8cee41899fc0e74bafa31000"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/search/zipball/28d6377306b3fe8ca6f46eafe63518ddde35bbc1",
-                "reference": "28d6377306b3fe8ca6f46eafe63518ddde35bbc1",
+                "url": "https://api.github.com/repos/waaseyaa/search/zipball/41ec53d24211442d8cee41899fc0e74bafa31000",
+                "reference": "41ec53d24211442d8cee41899fc0e74bafa31000",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
                 "symfony/event-dispatcher": "^7.0",
                 "twig/twig": "^3.0",
-                "waaseyaa/database-legacy": "@dev",
-                "waaseyaa/entity": "@dev",
-                "waaseyaa/foundation": "@dev"
+                "waaseyaa/database-legacy": "^0.1",
+                "waaseyaa/entity": "^0.1",
+                "waaseyaa/foundation": "^0.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -5371,32 +5873,35 @@
             "description": "Search provider interface and DTOs for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/search/issues",
-                "source": "https://github.com/waaseyaa/search/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/search/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-23T17:41:28+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/ssr",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ssr.git",
-                "reference": "3815a8d7366c5b28ac3f848de1d9944b4af382c3"
+                "reference": "d225a19a249b5cea86a5dba45c5b7ebc7d0a3e83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/ssr/zipball/3815a8d7366c5b28ac3f848de1d9944b4af382c3",
-                "reference": "3815a8d7366c5b28ac3f848de1d9944b4af382c3",
+                "url": "https://api.github.com/repos/waaseyaa/ssr/zipball/d225a19a249b5cea86a5dba45c5b7ebc7d0a3e83",
+                "reference": "d225a19a249b5cea86a5dba45c5b7ebc7d0a3e83",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
+                "symfony/html-sanitizer": "^8.0",
                 "twig/twig": "^3.0",
                 "waaseyaa/access": "^0.1",
+                "waaseyaa/api": "^0.1",
                 "waaseyaa/cache": "^0.1",
                 "waaseyaa/config": "^0.1",
                 "waaseyaa/entity": "^0.1",
                 "waaseyaa/field": "^0.1",
+                "waaseyaa/foundation": "^0.1",
                 "waaseyaa/routing": "^0.1"
             },
             "require-dev": {
@@ -5427,22 +5932,22 @@
             "description": "Server-side rendering with Twig templates for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ssr/issues",
-                "source": "https://github.com/waaseyaa/ssr/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/ssr/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-30T16:26:08+00:00"
+            "time": "2026-04-09T02:36:46+00:00"
         },
         {
             "name": "waaseyaa/state",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/state.git",
-                "reference": "c569028bc730805482bd79dde075c5bdd2d472f2"
+                "reference": "160f6879367bdc8f410e0ce9073a6a34b8b55949"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/state/zipball/c569028bc730805482bd79dde075c5bdd2d472f2",
-                "reference": "c569028bc730805482bd79dde075c5bdd2d472f2",
+                "url": "https://api.github.com/repos/waaseyaa/state/zipball/160f6879367bdc8f410e0ce9073a6a34b8b55949",
+                "reference": "160f6879367bdc8f410e0ce9073a6a34b8b55949",
                 "shasum": ""
             },
             "require": {
@@ -5471,22 +5976,22 @@
             "description": "Key-value state storage for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/state/issues",
-                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T00:46:26+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/taxonomy",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/taxonomy.git",
-                "reference": "75357e2c663b55a2669d8cf9ce33995ec7a3bb79"
+                "reference": "99a66a32404ce3253404bc780d422d8b68a2bafa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/taxonomy/zipball/75357e2c663b55a2669d8cf9ce33995ec7a3bb79",
-                "reference": "75357e2c663b55a2669d8cf9ce33995ec7a3bb79",
+                "url": "https://api.github.com/repos/waaseyaa/taxonomy/zipball/99a66a32404ce3253404bc780d422d8b68a2bafa",
+                "reference": "99a66a32404ce3253404bc780d422d8b68a2bafa",
                 "shasum": ""
             },
             "require": {
@@ -5521,65 +6026,22 @@
             "description": "Taxonomy vocabulary and term entity types for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/taxonomy/issues",
-                "source": "https://github.com/waaseyaa/taxonomy/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/taxonomy/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-30T16:26:08+00:00"
-        },
-        {
-            "name": "waaseyaa/telescope",
-            "version": "v0.1.0-alpha.104",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/waaseyaa/telescope.git",
-                "reference": "ab374ec4966e759e3a45e986119a281466f0d3c6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/telescope/zipball/ab374ec4966e759e3a45e986119a281466f0d3c6",
-                "reference": "ab374ec4966e759e3a45e986119a281466f0d3c6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "0.1.x-dev",
-                    "dev-develop/v1.1": "0.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Waaseyaa\\Telescope\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Application observability and debugging for Waaseyaa",
-            "support": {
-                "issues": "https://github.com/waaseyaa/telescope/issues",
-                "source": "https://github.com/waaseyaa/telescope/tree/v0.1.0-alpha.104"
-            },
-            "time": "2026-04-04T00:46:26+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/testing",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/testing.git",
-                "reference": "28937148e6faec2d358b05f6100542b9d95fee4f"
+                "reference": "44925438a142af369e3362bfea21f570bc5b9d8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/testing/zipball/28937148e6faec2d358b05f6100542b9d95fee4f",
-                "reference": "28937148e6faec2d358b05f6100542b9d95fee4f",
+                "url": "https://api.github.com/repos/waaseyaa/testing/zipball/44925438a142af369e3362bfea21f570bc5b9d8f",
+                "reference": "44925438a142af369e3362bfea21f570bc5b9d8f",
                 "shasum": ""
             },
             "require": {
@@ -5606,27 +6068,27 @@
             "description": "Testing utilities for Waaseyaa — base test case, entity factories, and helper traits.",
             "support": {
                 "issues": "https://github.com/waaseyaa/testing/issues",
-                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-04T00:58:32+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/typed-data",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/typed-data.git",
-                "reference": "9dd618113666cb4c50ce5f87eeef6ee9c7fe352b"
+                "reference": "66027bb4a37498708dabbcaf0e529fd3c401cabd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/typed-data/zipball/9dd618113666cb4c50ce5f87eeef6ee9c7fe352b",
-                "reference": "9dd618113666cb4c50ce5f87eeef6ee9c7fe352b",
+                "url": "https://api.github.com/repos/waaseyaa/typed-data/zipball/66027bb4a37498708dabbcaf0e529fd3c401cabd",
+                "reference": "66027bb4a37498708dabbcaf0e529fd3c401cabd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "symfony/validator": "^7.3"
+                "symfony/validator": "^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
@@ -5650,22 +6112,22 @@
             "description": "Type system with PHP-native facade for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/typed-data/issues",
-                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-16T21:50:01+00:00"
+            "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/user",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/user.git",
-                "reference": "e83130b4eb19c2feb3a533132a172d2123ae5a6b"
+                "reference": "01a3a99bb4e676f2e7e34e64822e1a01f481b00b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/user/zipball/e83130b4eb19c2feb3a533132a172d2123ae5a6b",
-                "reference": "e83130b4eb19c2feb3a533132a172d2123ae5a6b",
+                "url": "https://api.github.com/repos/waaseyaa/user/zipball/01a3a99bb4e676f2e7e34e64822e1a01f481b00b",
+                "reference": "01a3a99bb4e676f2e7e34e64822e1a01f481b00b",
                 "shasum": ""
             },
             "require": {
@@ -5704,27 +6166,27 @@
             "description": "User entity, authentication, and session management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/user/issues",
-                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-04-03T20:07:25+00:00"
+            "time": "2026-04-09T02:22:27+00:00"
         },
         {
             "name": "waaseyaa/validation",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/validation.git",
-                "reference": "0df42910835b3668fe0a00f72f381f179787c6ef"
+                "reference": "f26a5e026d5f7e1911861de78b6b6c2298f179e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/validation/zipball/0df42910835b3668fe0a00f72f381f179787c6ef",
-                "reference": "0df42910835b3668fe0a00f72f381f179787c6ef",
+                "url": "https://api.github.com/repos/waaseyaa/validation/zipball/f26a5e026d5f7e1911861de78b6b6c2298f179e2",
+                "reference": "f26a5e026d5f7e1911861de78b6b6c2298f179e2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
-                "symfony/validator": "^7.3",
+                "symfony/validator": "^7.0",
                 "waaseyaa/typed-data": "^0.1"
             },
             "require-dev": {
@@ -5749,22 +6211,22 @@
             "description": "Data validation constraints and validators for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/validation/issues",
-                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-27T19:12:28+00:00"
+            "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/workflows",
-            "version": "v0.1.0-alpha.104",
+            "version": "v0.1.0-alpha.114",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/workflows.git",
-                "reference": "5305d6cbae2ce372edd0ac06848654413412fc94"
+                "reference": "3eb6ce2d237a0782c3390766ddce2d1de58b9a79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/workflows/zipball/5305d6cbae2ce372edd0ac06848654413412fc94",
-                "reference": "5305d6cbae2ce372edd0ac06848654413412fc94",
+                "url": "https://api.github.com/repos/waaseyaa/workflows/zipball/3eb6ce2d237a0782c3390766ddce2d1de58b9a79",
+                "reference": "3eb6ce2d237a0782c3390766ddce2d1de58b9a79",
                 "shasum": ""
             },
             "require": {
@@ -5800,9 +6262,9 @@
             "description": "Content moderation and editorial workflow states for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/workflows/issues",
-                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.104"
+                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.114"
             },
-            "time": "2026-03-29T16:26:20+00:00"
+            "time": "2026-04-08T15:25:48+00:00"
         }
     ],
     "packages-dev": [

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -89,7 +89,14 @@ Current app controllers use the SSR dispatch signature:
 public function action(array $params, array $query, AccountInterface $account, HttpRequest $request): InertiaResponse
 ```
 
-Controllers should guard optional services explicitly and return `bootError` props when required service wiring is missing.
+Symfony `HttpRequest` remains the dispatcher’s fourth argument. Inside the handler, build
+`Waaseyaa\Foundation\Http\Inbound\InboundHttpRequest::fromSymfonyRequest($request, $params, $query)` when passing a read-only HTTP view into application code—do not thread Symfony types deeper than the controller layer.
+
+Controllers should guard optional services explicitly and return `bootError` props when required service wiring is missing. After a null guard, assign dependencies to locals (e.g. `$searchService = $this->searchService`) so downstream calls are clearly non-null for readers and static analysis.
+
+### 2.4 Lifecycle drift guard
+
+`scripts/check-lifecycle-drift.sh` enforces that edits under watched paths (including `src/Http/Controller/`, `src/Pipeline/`, and the script itself) either update `docs/architecture/lifecycle.md` or are paired with an explicit doc note. The script uses `grep` when `rg` is unavailable so CI does not require ripgrep.
 
 ## 3. Data Lifecycle
 

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -1,0 +1,173 @@
+# Giiken Application Lifecycle
+
+This document describes how a request moves through Giiken at runtime, where app-level code hooks into Waaseyaa, and what invariants should remain true during refactoring.
+
+## Scope
+
+- App: `giiken`
+- Framework: `waaseyaa/*`
+- Entrypoint: `public/index.php`
+- Primary app integration point: `src/GiikenServiceProvider.php`
+
+## 1. Boot Lifecycle
+
+### 1.1 Entrypoint
+
+`public/index.php`:
+
+1. Loads Composer autoloader.
+2. Loads `.env` with `Symfony Dotenv` (fails fast with HTTP 500 on parse/path error).
+3. Instantiates `Waaseyaa\Foundation\Kernel\HttpKernel` with project root.
+4. Calls `$kernel->handle()` and then `$response->send()`.
+
+### 1.2 Kernel Boot Sequence
+
+Inside `HttpKernel::handle()` -> `AbstractKernel::boot()`:
+
+1. `EnvLoader::load()`
+2. `ConfigLoader::load()`
+3. Logger initialization from config
+4. Safety guard: deny debug in non-development env
+5. Core service bootstrap:
+   - database
+   - entity type manager
+   - package manifest compile
+   - migrations bootstrap
+6. Provider discovery/register (`ProviderRegistry::discoverAndRegister`)
+7. App entity type load + content type validation
+8. Provider boot (`ProviderRegistry::boot`)
+9. Access policy discovery
+10. Finalization (`HttpKernel::finalizeBoot`)
+
+### 1.3 Where Giiken Enters
+
+The first Giiken app-level class in normal boot is `Giiken\GiikenServiceProvider`:
+
+- `register()` contributes app entity types (`community`, `knowledge_item`, `wiki_lint_report`)
+- `routes()` contributes app HTTP routes
+
+## 2. Request Lifecycle
+
+### 2.1 High-level Request Path
+
+After boot, `HttpKernel::serveHttpRequest()` executes:
+
+1. CORS handling (`handleCors`)
+2. Route match (`WaaseyaaRouter`)
+3. Request object creation (`Request::createFromGlobals()`)
+4. Middleware pipeline:
+   - bearer auth
+   - session middleware
+   - CSRF
+   - authorization
+   - debug headers (if debug mode)
+   - provider middleware
+5. Account resolution (`_account` request attribute)
+6. Router dispatch (`ControllerDispatcher`)
+
+### 2.2 App Route Registration
+
+App routes are added through `GiikenServiceProvider::routes(...)`, including:
+
+- Discovery:
+  - `/{communitySlug}`
+  - `/{communitySlug}/search`
+  - `/{communitySlug}/ask`
+  - `/{communitySlug}/item/{itemId}`
+- Management:
+  - `/{communitySlug}/manage`
+  - `/{communitySlug}/manage/reports`
+  - `/{communitySlug}/manage/users`
+  - `/{communitySlug}/manage/ingestion`
+  - `/{communitySlug}/manage/export`
+
+### 2.3 Controller Dispatch Contract
+
+Current app controllers use the SSR dispatch signature:
+
+```php
+public function action(array $params, array $query, AccountInterface $account, HttpRequest $request): InertiaResponse
+```
+
+Controllers should guard optional services explicitly and return `bootError` props when required service wiring is missing.
+
+## 3. Data Lifecycle
+
+### 3.1 Entity Registration
+
+Entity types are declared in `GiikenServiceProvider::register()` and attached to `EntityTypeManager`.
+
+### 3.2 Repository Access
+
+App repositories (community, knowledge items) wrap framework repository/storage APIs:
+
+- load entities
+- filter by community/slug
+- save/delete with timestamp conventions
+
+### 3.3 Query + Pipeline Flow
+
+- Discovery/search flows enter through `SearchService`.
+- Q&A flows call `QaService` and then search for related items.
+- Compilation flows traverse pipeline steps and persist knowledge items via repository.
+
+## 4. Failure Lifecycle
+
+### 4.1 Boot-time failures
+
+- `HttpKernel::handle()` catches boot exceptions.
+- If `waaseyaa/error-handler` is available and debug is true, dev exception renderer can produce HTML.
+- Otherwise a JSON API error response is returned.
+
+### 4.2 Request-time failures
+
+- Unhandled request exceptions are logged and converted to JSON API 500 responses by kernel fallback.
+- If controllers are invoked through SSR and return invalid dispatch signatures or unresolved dependencies, runtime errors surface as 500s.
+
+### 4.3 Config-time failures
+
+`public/index.php` catches dotenv format/path errors before kernel boot and returns a plain HTTP 500 message.
+
+## 5. Extension Points
+
+Primary extension points for app work:
+
+- `src/GiikenServiceProvider.php`
+  - service registration
+  - entity type registration
+  - route registration
+- `src/Http/Controller/*`
+  - route handlers and UI response props
+- `src/Entity/*`, `src/Query/*`, `src/Pipeline/*`, `src/Export/*`
+  - domain behavior and cross-cutting flows
+
+## 6. Refactor Invariants
+
+Keep these true during refactoring:
+
+1. `public/index.php` always sends the response (`$response->send()`).
+2. Controllers keep the active dispatch signature expected by SSR dispatch.
+3. Optional service dependencies are handled with explicit guard returns (no implicit null behavior).
+4. `GiikenServiceProvider` remains the single source of app route/entity registration.
+5. Boot-time failures remain deterministic and observable (log + stable error response path).
+
+## 7. Refactor Impact Matrix
+
+| Area | Likely Impact | Verify With |
+|---|---|---|
+| `public/index.php` | global boot and response emission | smoke test `/`, non-zero body |
+| `src/GiikenServiceProvider.php` | route/entity discovery | route smoke tests + boot |
+| `src/Http/Controller/*` | SSR dispatch and Inertia props | unit tests + route smoke tests |
+| `src/Entity/*` and repositories | data shape, persistence behavior | unit tests + integration tests |
+| `src/Query/*`, `src/Pipeline/*` | search/qa/compile behavior | unit tests for services and steps |
+
+## 8. Minimal Verification Checklist
+
+After lifecycle-touching changes:
+
+1. `./vendor/bin/phpunit --testsuite Unit`
+2. `./vendor/bin/phpstan analyse src/`
+3. Start local server and verify:
+   - `/` returns 200 with non-zero body
+   - `/{communitySlug}` does not regress from known behavior
+

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  parallel: true
+  commands:
+    lifecycle-drift:
+      run: ./scripts/check-lifecycle-drift.sh
+
+pre-push:
+  parallel: true
+  commands:
+    lifecycle-drift:
+      run: ./scripts/check-lifecycle-drift.sh
+    phpunit:
+      run: ./vendor/bin/phpunit
+    phpstan:
+      run: ./vendor/bin/phpstan analyse src tests --level=8 --no-progress

--- a/public/index.php
+++ b/public/index.php
@@ -4,5 +4,16 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$kernel = new \Waaseyaa\Foundation\Kernel\HttpKernel(dirname(__DIR__));
-$kernel->handle();
+$projectRoot = dirname(__DIR__);
+try {
+    (new \Symfony\Component\Dotenv\Dotenv())->loadEnv($projectRoot . '/.env');
+} catch (\Symfony\Component\Dotenv\Exception\FormatException|\Symfony\Component\Dotenv\Exception\PathException $e) {
+    http_response_code(500);
+    error_log('Waaseyaa: Failed to load .env: ' . $e->getMessage());
+    echo 'Application configuration error. Check server logs.';
+    exit(1);
+}
+
+$kernel = new \Waaseyaa\Foundation\Kernel\HttpKernel($projectRoot);
+$response = $kernel->handle();
+$response->send();

--- a/scripts/check-lifecycle-drift.sh
+++ b/scripts/check-lifecycle-drift.sh
@@ -5,6 +5,8 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
 LIFECYCLE_DOC="docs/architecture/lifecycle.md"
+# Anchor path as literals in ERE: unescaped "." would match any character.
+LIFECYCLE_DOC_PATTERN="^${LIFECYCLE_DOC//./\\.}$"
 
 if [[ ! -f "$LIFECYCLE_DOC" ]]; then
   echo "FAIL: $LIFECYCLE_DOC is missing."
@@ -63,7 +65,7 @@ if [[ -z "${CHANGED_FILES}" ]]; then
 fi
 
 DOC_UPDATED=0
-if matches_pattern "^${LIFECYCLE_DOC}$"; then
+if matches_pattern "${LIFECYCLE_DOC_PATTERN}"; then
   DOC_UPDATED=1
 fi
 

--- a/scripts/check-lifecycle-drift.sh
+++ b/scripts/check-lifecycle-drift.sh
@@ -22,10 +22,33 @@ WATCH_PATTERNS=(
   "^src/Pipeline/.*\\.php$"
 )
 
+# Prefer ripgrep when available; otherwise use POSIX grep (no extra CI dependency).
+if command -v rg >/dev/null 2>&1; then
+  matches_pattern() {
+    echo "${CHANGED_FILES}" | rg -q "$1"
+  }
+else
+  matches_pattern() {
+    echo "${CHANGED_FILES}" | grep -qE "$1"
+  }
+fi
+
 if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
   BASE_REF="${GITHUB_BASE_REF:-main}"
-  git fetch --no-tags --depth=1 origin "${BASE_REF}"
-  CHANGED_FILES="$(git diff --name-only "origin/${BASE_REF}...HEAD")"
+  if git remote get-url origin >/dev/null 2>&1; then
+    if ! git fetch --no-tags --depth=1 origin "${BASE_REF}"; then
+      echo "FAIL: Could not git fetch origin ${BASE_REF}. Check network, credentials, and that the remote ref exists." >&2
+      exit 2
+    fi
+    CHANGED_FILES="$(git diff --name-only "origin/${BASE_REF}...HEAD")"
+  else
+    echo "WARN: Git remote 'origin' not configured; using HEAD~1..HEAD for lifecycle drift (PR context)." >&2
+    if git rev-parse HEAD~1 >/dev/null 2>&1; then
+      CHANGED_FILES="$(git diff --name-only HEAD~1..HEAD)"
+    else
+      CHANGED_FILES=""
+    fi
+  fi
 else
   if git rev-parse HEAD~1 >/dev/null 2>&1; then
     CHANGED_FILES="$(git diff --name-only HEAD~1..HEAD)"
@@ -40,13 +63,13 @@ if [[ -z "${CHANGED_FILES}" ]]; then
 fi
 
 DOC_UPDATED=0
-if echo "${CHANGED_FILES}" | rg -q "^${LIFECYCLE_DOC}$"; then
+if matches_pattern "^${LIFECYCLE_DOC}$"; then
   DOC_UPDATED=1
 fi
 
 WATCH_HIT=0
 for pattern in "${WATCH_PATTERNS[@]}"; do
-  if echo "${CHANGED_FILES}" | rg -q "${pattern}"; then
+  if matches_pattern "${pattern}"; then
     WATCH_HIT=1
     break
   fi

--- a/scripts/check-lifecycle-drift.sh
+++ b/scripts/check-lifecycle-drift.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+LIFECYCLE_DOC="docs/architecture/lifecycle.md"
+
+if [[ ! -f "$LIFECYCLE_DOC" ]]; then
+  echo "FAIL: $LIFECYCLE_DOC is missing."
+  exit 1
+fi
+
+# Files that usually imply lifecycle behavior changes.
+WATCH_PATTERNS=(
+  "^public/index\\.php$"
+  "^src/GiikenServiceProvider\\.php$"
+  "^src/Http/Controller/.*\\.php$"
+  "^src/Http/Middleware/.*\\.php$"
+  "^src/Entity/.*\\.php$"
+  "^src/Query/.*\\.php$"
+  "^src/Pipeline/.*\\.php$"
+)
+
+if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+  BASE_REF="${GITHUB_BASE_REF:-main}"
+  git fetch --no-tags --depth=1 origin "${BASE_REF}"
+  CHANGED_FILES="$(git diff --name-only "origin/${BASE_REF}...HEAD")"
+else
+  if git rev-parse HEAD~1 >/dev/null 2>&1; then
+    CHANGED_FILES="$(git diff --name-only HEAD~1..HEAD)"
+  else
+    CHANGED_FILES=""
+  fi
+fi
+
+if [[ -z "${CHANGED_FILES}" ]]; then
+  echo "OK: No changed files detected for lifecycle drift check."
+  exit 0
+fi
+
+DOC_UPDATED=0
+if echo "${CHANGED_FILES}" | rg -q "^${LIFECYCLE_DOC}$"; then
+  DOC_UPDATED=1
+fi
+
+WATCH_HIT=0
+for pattern in "${WATCH_PATTERNS[@]}"; do
+  if echo "${CHANGED_FILES}" | rg -q "${pattern}"; then
+    WATCH_HIT=1
+    break
+  fi
+done
+
+if [[ "${WATCH_HIT}" -eq 1 && "${DOC_UPDATED}" -eq 0 ]]; then
+  echo "FAIL: Lifecycle-impacting files changed without updating ${LIFECYCLE_DOC}."
+  echo "Changed files:"
+  echo "${CHANGED_FILES}" | sed 's/^/  - /'
+  echo
+  echo "Update ${LIFECYCLE_DOC} (or include a note that no lifecycle behavior changed)."
+  exit 1
+fi
+
+echo "OK: Lifecycle doc drift check passed."

--- a/src/Http/Controller/DiscoveryController.php
+++ b/src/Http/Controller/DiscoveryController.php
@@ -11,6 +11,7 @@ use Giiken\Query\QaServiceInterface;
 use Giiken\Query\SearchQuery;
 use Giiken\Query\SearchResultSet;
 use Giiken\Query\SearchService;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Inertia\Inertia;
 use Waaseyaa\Inertia\InertiaResponse;
@@ -18,15 +19,35 @@ use Waaseyaa\Inertia\InertiaResponse;
 final class DiscoveryController
 {
     public function __construct(
-        private readonly SearchService $searchService,
-        private readonly QaServiceInterface $qaService,
-        private readonly CommunityRepositoryInterface $communityRepo,
-        private readonly KnowledgeItemRepositoryInterface $itemRepo,
+        private readonly ?SearchService $searchService = null,
+        private readonly ?QaServiceInterface $qaService = null,
+        private readonly ?CommunityRepositoryInterface $communityRepo = null,
+        private readonly ?KnowledgeItemRepositoryInterface $itemRepo = null,
     ) {}
 
-    public function index(string $communitySlug, ?AccountInterface $account): InertiaResponse
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function index(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
     {
+        $communitySlug = (string) ($params['communitySlug'] ?? '');
+
+        if ($this->searchService === null || $this->communityRepo === null) {
+            return Inertia::render('Discovery/Index', [
+                'community' => null,
+                'recentItems' => $this->emptyResultSet(),
+                'bootError' => 'Discovery services are not configured yet.',
+            ]);
+        }
+
         $community = $this->communityRepo->findBySlug($communitySlug);
+        if ($community === null) {
+            return Inertia::render('Discovery/Index', [
+                'community' => null,
+                'recentItems' => $this->emptyResultSet(),
+            ]);
+        }
 
         $recent = $this->searchService->search(
             new SearchQuery(query: '', communityId: (string) $community->get('id')),
@@ -39,17 +60,43 @@ final class DiscoveryController
         ]);
     }
 
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
     public function search(
-        string $communitySlug,
-        string $query,
-        int $page,
-        ?AccountInterface $account,
+        array $params,
+        array $query,
+        AccountInterface $account,
+        HttpRequest $httpRequest,
     ): InertiaResponse {
+        $communitySlug = (string) ($params['communitySlug'] ?? '');
+        $searchQuery = (string) ($query['query'] ?? '');
+        $page = max(1, (int) ($query['page'] ?? 1));
+
+        if ($this->searchService === null || $this->communityRepo === null) {
+            return Inertia::render('Discovery/Search', [
+                'community' => null,
+                'query' => $searchQuery,
+                'results' => $this->emptyResultSet(),
+                'page' => $page,
+                'bootError' => 'Search services are not configured yet.',
+            ]);
+        }
+
         $community = $this->communityRepo->findBySlug($communitySlug);
+        if ($community === null) {
+            return Inertia::render('Discovery/Search', [
+                'community' => null,
+                'query' => $searchQuery,
+                'results' => $this->emptyResultSet(),
+                'page' => $page,
+            ]);
+        }
 
         $results = $this->searchService->search(
             new SearchQuery(
-                query: $query,
+                query: $searchQuery,
                 communityId: (string) $community->get('id'),
                 page: $page,
             ),
@@ -58,15 +105,44 @@ final class DiscoveryController
 
         return Inertia::render('Discovery/Search', [
             'community' => $this->serializeCommunity($community),
-            'query' => $query,
+            'query' => $searchQuery,
             'results' => $this->serializeResultSet($results),
             'page' => $page,
         ]);
     }
 
-    public function ask(string $communitySlug, string $question, ?AccountInterface $account): InertiaResponse
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function ask(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
     {
+        $communitySlug = (string) ($params['communitySlug'] ?? '');
+        $question = (string) ($query['question'] ?? '');
+
+        if ($this->searchService === null || $this->qaService === null || $this->communityRepo === null) {
+            return Inertia::render('Discovery/Ask', [
+                'community' => null,
+                'question' => $question,
+                'answer' => '',
+                'citedItemIds' => [],
+                'noRelevantItems' => true,
+                'relatedItems' => $this->emptyResultSet(),
+                'bootError' => 'Q&A services are not configured yet.',
+            ]);
+        }
+
         $community = $this->communityRepo->findBySlug($communitySlug);
+        if ($community === null) {
+            return Inertia::render('Discovery/Ask', [
+                'community' => null,
+                'question' => $question,
+                'answer' => '',
+                'citedItemIds' => [],
+                'noRelevantItems' => true,
+                'relatedItems' => $this->emptyResultSet(),
+            ]);
+        }
         $communityId = (string) $community->get('id');
 
         $qaResponse = $this->qaService->ask($question, $communityId, $account);
@@ -86,10 +162,31 @@ final class DiscoveryController
         ]);
     }
 
-    public function show(string $communitySlug, string $itemId, ?AccountInterface $account): InertiaResponse
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function show(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
     {
+        $communitySlug = (string) ($params['communitySlug'] ?? '');
+        $itemId = (string) ($params['itemId'] ?? '');
+
+        if ($this->communityRepo === null || $this->itemRepo === null) {
+            return Inertia::render('Discovery/Show', [
+                'community' => null,
+                'item' => null,
+                'bootError' => 'Knowledge item services are not configured yet.',
+            ]);
+        }
+
         $community = $this->communityRepo->findBySlug($communitySlug);
         $item = $this->itemRepo->find($itemId);
+        if ($community === null || $item === null) {
+            return Inertia::render('Discovery/Show', [
+                'community' => $community !== null ? $this->serializeCommunity($community) : null,
+                'item' => null,
+            ]);
+        }
 
         return Inertia::render('Discovery/Show', [
             'community' => $this->serializeCommunity($community),
@@ -134,6 +231,18 @@ final class DiscoveryController
             ], $resultSet->items),
             'totalHits' => $resultSet->totalHits,
             'totalPages' => $resultSet->totalPages,
+        ];
+    }
+
+    /**
+     * @return array{items: array<array<string, mixed>>, totalHits: int, totalPages: int}
+     */
+    private function emptyResultSet(): array
+    {
+        return [
+            'items' => [],
+            'totalHits' => 0,
+            'totalPages' => 0,
         ];
     }
 }

--- a/src/Http/Controller/DiscoveryController.php
+++ b/src/Http/Controller/DiscoveryController.php
@@ -13,6 +13,7 @@ use Giiken\Query\SearchResultSet;
 use Giiken\Query\SearchService;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Foundation\Http\Inbound\InboundHttpRequest;
 use Waaseyaa\Inertia\Inertia;
 use Waaseyaa\Inertia\InertiaResponse;
 
@@ -31,7 +32,8 @@ final class DiscoveryController
      */
     public function index(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
     {
-        $communitySlug = (string) ($params['communitySlug'] ?? '');
+        $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
+        $communitySlug = (string) $inbound->routeParam('communitySlug', '');
 
         if ($this->searchService === null || $this->communityRepo === null) {
             return Inertia::render('Discovery/Index', [
@@ -41,7 +43,10 @@ final class DiscoveryController
             ]);
         }
 
-        $community = $this->communityRepo->findBySlug($communitySlug);
+        $searchService = $this->searchService;
+        $communityRepo = $this->communityRepo;
+
+        $community = $communityRepo->findBySlug($communitySlug);
         if ($community === null) {
             return Inertia::render('Discovery/Index', [
                 'community' => null,
@@ -49,7 +54,7 @@ final class DiscoveryController
             ]);
         }
 
-        $recent = $this->searchService->search(
+        $recent = $searchService->search(
             new SearchQuery(query: '', communityId: (string) $community->get('id')),
             $account,
         );
@@ -70,11 +75,10 @@ final class DiscoveryController
         AccountInterface $account,
         HttpRequest $httpRequest,
     ): InertiaResponse {
-        $communitySlug = (string) ($params['communitySlug'] ?? '');
-        $searchQuery = (string) ($query['query'] ?? '');
-        $page = max(1, (int) ($query['page'] ?? 1));
-
         if ($this->searchService === null || $this->communityRepo === null) {
+            $searchQuery = (string) ($query['query'] ?? '');
+            $page = max(1, (int) ($query['page'] ?? 1));
+
             return Inertia::render('Discovery/Search', [
                 'community' => null,
                 'query' => $searchQuery,
@@ -84,7 +88,15 @@ final class DiscoveryController
             ]);
         }
 
-        $community = $this->communityRepo->findBySlug($communitySlug);
+        $searchService = $this->searchService;
+        $communityRepo = $this->communityRepo;
+
+        $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
+        $communitySlug = (string) $inbound->routeParam('communitySlug', '');
+        $searchQuery = (string) $inbound->queryParam('query', '');
+        $page = max(1, (int) $inbound->queryParam('page', 1));
+
+        $community = $communityRepo->findBySlug($communitySlug);
         if ($community === null) {
             return Inertia::render('Discovery/Search', [
                 'community' => null,
@@ -94,7 +106,7 @@ final class DiscoveryController
             ]);
         }
 
-        $results = $this->searchService->search(
+        $results = $searchService->search(
             new SearchQuery(
                 query: $searchQuery,
                 communityId: (string) $community->get('id'),
@@ -117,10 +129,9 @@ final class DiscoveryController
      */
     public function ask(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
     {
-        $communitySlug = (string) ($params['communitySlug'] ?? '');
-        $question = (string) ($query['question'] ?? '');
-
         if ($this->searchService === null || $this->qaService === null || $this->communityRepo === null) {
+            $question = (string) ($query['question'] ?? '');
+
             return Inertia::render('Discovery/Ask', [
                 'community' => null,
                 'question' => $question,
@@ -132,7 +143,15 @@ final class DiscoveryController
             ]);
         }
 
-        $community = $this->communityRepo->findBySlug($communitySlug);
+        $searchService = $this->searchService;
+        $qaService = $this->qaService;
+        $communityRepo = $this->communityRepo;
+
+        $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
+        $communitySlug = (string) $inbound->routeParam('communitySlug', '');
+        $question = (string) $inbound->queryParam('question', '');
+
+        $community = $communityRepo->findBySlug($communitySlug);
         if ($community === null) {
             return Inertia::render('Discovery/Ask', [
                 'community' => null,
@@ -145,9 +164,9 @@ final class DiscoveryController
         }
         $communityId = (string) $community->get('id');
 
-        $qaResponse = $this->qaService->ask($question, $communityId, $account);
+        $qaResponse = $qaService->ask($question, $communityId, $account);
 
-        $related = $this->searchService->search(
+        $related = $searchService->search(
             new SearchQuery(query: $question, communityId: $communityId, pageSize: 5),
             $account,
         );
@@ -168,9 +187,6 @@ final class DiscoveryController
      */
     public function show(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
     {
-        $communitySlug = (string) ($params['communitySlug'] ?? '');
-        $itemId = (string) ($params['itemId'] ?? '');
-
         if ($this->communityRepo === null || $this->itemRepo === null) {
             return Inertia::render('Discovery/Show', [
                 'community' => null,
@@ -179,8 +195,15 @@ final class DiscoveryController
             ]);
         }
 
-        $community = $this->communityRepo->findBySlug($communitySlug);
-        $item = $this->itemRepo->find($itemId);
+        $communityRepo = $this->communityRepo;
+        $itemRepo = $this->itemRepo;
+
+        $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
+        $communitySlug = (string) $inbound->routeParam('communitySlug', '');
+        $itemId = (string) $inbound->routeParam('itemId', '');
+
+        $community = $communityRepo->findBySlug($communitySlug);
+        $item = $itemRepo->find($itemId);
         if ($community === null || $item === null) {
             return Inertia::render('Discovery/Show', [
                 'community' => $community !== null ? $this->serializeCommunity($community) : null,

--- a/src/Http/Controller/ManagementController.php
+++ b/src/Http/Controller/ManagementController.php
@@ -8,6 +8,7 @@ use Giiken\Entity\Community\Community;
 use Giiken\Entity\Community\CommunityRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Foundation\Http\Inbound\InboundHttpRequest;
 use Waaseyaa\Inertia\Inertia;
 use Waaseyaa\Inertia\InertiaResponse;
 
@@ -30,7 +31,8 @@ final class ManagementController
             ]);
         }
 
-        $communitySlug = (string) ($params['communitySlug'] ?? '');
+        $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
+        $communitySlug = (string) $inbound->routeParam('communitySlug', '');
         $community = $this->communityRepo->findBySlug($communitySlug);
         return Inertia::render('Management/Dashboard', [
             'community' => $community !== null ? $this->serializeCommunity($community) : null,
@@ -52,7 +54,8 @@ final class ManagementController
             ]);
         }
 
-        $communitySlug = (string) ($params['communitySlug'] ?? '');
+        $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
+        $communitySlug = (string) $inbound->routeParam('communitySlug', '');
         $community = $this->communityRepo->findBySlug($communitySlug);
         return Inertia::render('Management/Reports', [
             'community'   => $community !== null ? $this->serializeCommunity($community) : null,
@@ -74,7 +77,8 @@ final class ManagementController
             ]);
         }
 
-        $communitySlug = (string) ($params['communitySlug'] ?? '');
+        $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
+        $communitySlug = (string) $inbound->routeParam('communitySlug', '');
         $community = $this->communityRepo->findBySlug($communitySlug);
         return Inertia::render('Management/Users', [
             'community' => $community !== null ? $this->serializeCommunity($community) : null,
@@ -95,7 +99,8 @@ final class ManagementController
             ]);
         }
 
-        $communitySlug = (string) ($params['communitySlug'] ?? '');
+        $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
+        $communitySlug = (string) $inbound->routeParam('communitySlug', '');
         $community = $this->communityRepo->findBySlug($communitySlug);
         return Inertia::render('Management/Ingestion', [
             'community' => $community !== null ? $this->serializeCommunity($community) : null,
@@ -116,7 +121,8 @@ final class ManagementController
             ]);
         }
 
-        $communitySlug = (string) ($params['communitySlug'] ?? '');
+        $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
+        $communitySlug = (string) $inbound->routeParam('communitySlug', '');
         $community = $this->communityRepo->findBySlug($communitySlug);
         return Inertia::render('Management/Export', [
             'community' => $community !== null ? $this->serializeCommunity($community) : null,

--- a/src/Http/Controller/ManagementController.php
+++ b/src/Http/Controller/ManagementController.php
@@ -6,62 +6,127 @@ namespace Giiken\Http\Controller;
 
 use Giiken\Entity\Community\Community;
 use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Export\ExportServiceInterface;
-use Giiken\Export\ImportServiceInterface;
-use Giiken\Query\Report\ReportServiceInterface;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Inertia\Inertia;
 use Waaseyaa\Inertia\InertiaResponse;
 
 final class ManagementController
 {
     public function __construct(
-        private readonly CommunityRepositoryInterface $communityRepo,
-        private readonly ReportServiceInterface $reportService,
-        private readonly ExportServiceInterface $exportService,
-        private readonly ImportServiceInterface $importService,
+        private readonly ?CommunityRepositoryInterface $communityRepo = null,
     ) {}
 
-    public function dashboard(string $communitySlug): InertiaResponse
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function dashboard(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
     {
+        if ($this->communityRepo === null) {
+            return Inertia::render('Management/Dashboard', [
+                'community' => null,
+                'bootError' => 'Management services are not configured yet.',
+            ]);
+        }
+
+        $communitySlug = (string) ($params['communitySlug'] ?? '');
         $community = $this->communityRepo->findBySlug($communitySlug);
         return Inertia::render('Management/Dashboard', [
-            'community' => $this->serializeCommunity($community),
+            'community' => $community !== null ? $this->serializeCommunity($community) : null,
+            'bootError' => null,
         ]);
     }
 
-    public function reports(string $communitySlug): InertiaResponse
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function reports(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
     {
+        if ($this->communityRepo === null) {
+            return Inertia::render('Management/Reports', [
+                'community' => null,
+                'reportTypes' => ['governance_summary', 'language_report', 'land_brief'],
+                'bootError' => 'Report services are not configured yet.',
+            ]);
+        }
+
+        $communitySlug = (string) ($params['communitySlug'] ?? '');
         $community = $this->communityRepo->findBySlug($communitySlug);
         return Inertia::render('Management/Reports', [
-            'community'   => $this->serializeCommunity($community),
+            'community'   => $community !== null ? $this->serializeCommunity($community) : null,
             'reportTypes' => ['governance_summary', 'language_report', 'land_brief'],
+            'bootError' => null,
         ]);
     }
 
-    public function users(string $communitySlug): InertiaResponse
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function users(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
     {
+        if ($this->communityRepo === null) {
+            return Inertia::render('Management/Users', [
+                'community' => null,
+                'bootError' => 'User services are not configured yet.',
+            ]);
+        }
+
+        $communitySlug = (string) ($params['communitySlug'] ?? '');
         $community = $this->communityRepo->findBySlug($communitySlug);
         return Inertia::render('Management/Users', [
-            'community' => $this->serializeCommunity($community),
+            'community' => $community !== null ? $this->serializeCommunity($community) : null,
+            'bootError' => null,
         ]);
     }
 
-    public function ingestion(string $communitySlug): InertiaResponse
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function ingestion(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
     {
+        if ($this->communityRepo === null) {
+            return Inertia::render('Management/Ingestion', [
+                'community' => null,
+                'bootError' => 'Ingestion services are not configured yet.',
+            ]);
+        }
+
+        $communitySlug = (string) ($params['communitySlug'] ?? '');
         $community = $this->communityRepo->findBySlug($communitySlug);
         return Inertia::render('Management/Ingestion', [
-            'community' => $this->serializeCommunity($community),
+            'community' => $community !== null ? $this->serializeCommunity($community) : null,
+            'bootError' => null,
         ]);
     }
 
-    public function exportPage(string $communitySlug): InertiaResponse
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function exportPage(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
     {
+        if ($this->communityRepo === null) {
+            return Inertia::render('Management/Export', [
+                'community' => null,
+                'bootError' => 'Export/import services are not configured yet.',
+            ]);
+        }
+
+        $communitySlug = (string) ($params['communitySlug'] ?? '');
         $community = $this->communityRepo->findBySlug($communitySlug);
         return Inertia::render('Management/Export', [
-            'community' => $this->serializeCommunity($community),
+            'community' => $community !== null ? $this->serializeCommunity($community) : null,
+            'bootError' => null,
         ]);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function serializeCommunity(Community $community): array
     {
         return [

--- a/templates/404.html.twig
+++ b/templates/404.html.twig
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>404 Not Found</title>
+</head>
+<body>
+  <main>
+    <h1>Not Found</h1>
+    <p>{{ path }}</p>
+  </main>
+</body>
+</html>

--- a/templates/home.html.twig
+++ b/templates/home.html.twig
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ title }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,300;0,400;0,500;1,400&family=Noto+Sans:wght@300;400&family=Noto+Sans+SC:wght@300&family=Noto+Sans+JP:wght@300&family=Noto+Sans+KR:wght@300&family=Noto+Sans+Thai:wght@300&family=Noto+Sans+Devanagari:wght@300&family=Noto+Sans+Arabic:wght@300&family=Noto+Sans+Hebrew:wght@300&family=Noto+Sans+Bengali:wght@300&family=Noto+Sans+Tamil:wght@300&family=Noto+Sans+Kannada:wght@300&family=Noto+Sans+Georgian:wght@300&family=Noto+Sans+Armenian:wght@300&family=Noto+Sans+Khmer:wght@300&family=Noto+Sans+Lao:wght@300&family=Noto+Sans+Myanmar:wght@300&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Inter', 'Noto Sans', 'Noto Sans SC', 'Noto Sans JP', 'Noto Sans KR', 'Noto Sans Thai', 'Noto Sans Devanagari', 'Noto Sans Arabic', 'Noto Sans Hebrew', 'Noto Sans Bengali', 'Noto Sans Tamil', 'Noto Sans Kannada', 'Noto Sans Georgian', 'Noto Sans Armenian', 'Noto Sans Khmer', 'Noto Sans Lao', 'Noto Sans Myanmar', sans-serif;
+      background: #0a0a0a;
+      color: #fafafa;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    main {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      flex: 1;
+      width: 100%;
+      padding: 0 24px;
+    }
+
+    .greeting {
+      font-size: clamp(3rem, 8vw, 6rem);
+      font-weight: 300;
+      letter-spacing: -0.02em;
+      line-height: 1.3;
+      text-align: center;
+      margin-bottom: 32px;
+      min-height: 1.3em;
+      opacity: 1;
+      transition: opacity 0.6s ease-in-out;
+    }
+
+    .greeting.fade-out {
+      opacity: 0;
+    }
+
+    .greeting[dir="rtl"] {
+      direction: rtl;
+      unicode-bidi: bidi-override;
+    }
+
+    .tagline {
+      font-size: 0.95rem;
+      font-weight: 400;
+      font-style: italic;
+      color: #525252;
+      letter-spacing: 0.04em;
+      margin-bottom: 20px;
+    }
+
+    .nav {
+      display: flex;
+      gap: 32px;
+    }
+
+    .nav a {
+      color: #525252;
+      text-decoration: none;
+      font-size: 0.85rem;
+      font-weight: 400;
+      letter-spacing: 0.02em;
+      transition: color 0.2s ease;
+    }
+
+    .nav a:hover {
+      color: #fafafa;
+    }
+
+    footer {
+      padding: 24px;
+      text-align: center;
+    }
+
+    footer p {
+      font-size: 0.75rem;
+      color: #333;
+    }
+
+    footer code {
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      font-size: 0.7rem;
+      color: #444;
+    }
+
+    @media (max-width: 480px) {
+      .nav { gap: 20px; }
+      .tagline { font-size: 0.85rem; margin-bottom: 36px; }
+    }
+  </style>
+</head>
+<body>
+
+  <main>
+      <div class="greeting" id="greeting"
+        data-greetings="Ahnii,Hello,Bonjour,Hola,你好,こんにちは,안녕하세요,नमस्ते,สวัสดี,Xin chào,مرحبا,שלום,سلام,Привет,Вітаю,Cześć,Ahoj,Hej,Hei,Moi,Halló,Γεια σου,Merhaba,Sawubona,Habari,Jambo,Salama,Aloha,Kia ora,Bula,Talofa,Hallo,Olá,Ciao,Salut,Здраво,Здравей,Sveiki,Labas,Tere,Szia,Kamusta,Selamat,ស្វស្តី,ສະບາຍດີ,မင်္ဂလာပါ,Osiyo,Hau,Yá'át'ééh,Tânsi,Kwey,Barka,Sannu,Ẹ kú,Kedu,Dumela,Salibonani,Mhoro,Mbote,Muraho,Ayubowan,Vanakkam,Namaskāra,Namaskar,নমস্কার,Sat Srī Akāl,Assalamu Alaikum,Salom,Salam,Barev,Gamarjoba,Përshëndetje,Mirëdita,Saluton,Dia duit,Helo,Demat,Bonghjornu,Saħħa,Tēnā koe,Bok,Živjo,Dobry den,Kaixo,Agur"
+        data-rtl="مرحبا,שלום,سلام,Assalamu Alaikum,اسلام علیکم"
+      >Ahnii</div>
+
+    <p class="tagline">{{ title }}</p>
+
+    <nav class="nav">
+      <a href="/admin">Admin</a>
+      <a href="/api">API</a>
+      <a href="https://github.com/waaseyaa/framework">Docs</a>
+    </nav>
+  </main>
+
+  <footer>
+    <p>Edit <code>templates/home.html.twig</code> to replace this page</p>
+  </footer>
+
+  <script>
+    (function () {
+      var el = document.getElementById('greeting');
+      if (!el) return;
+
+      var all = el.getAttribute('data-greetings').split(',');
+      var rtlSet = new Set((el.getAttribute('data-rtl') || '').split(','));
+      var first = all[0];
+      var rest = all.slice(1);
+      var queue = shuffle(rest.slice());
+      var delay = 2400;
+
+      function shuffle(arr) {
+        for (var i = arr.length - 1; i > 0; i--) {
+          var j = Math.floor(Math.random() * (i + 1));
+          var tmp = arr[i]; arr[i] = arr[j]; arr[j] = tmp;
+        }
+        return arr;
+      }
+
+      function next() {
+        if (queue.length === 0) {
+          queue = shuffle(rest.slice());
+          queue.unshift(first);
+        }
+        var word = queue.shift();
+        el.classList.add('fade-out');
+        setTimeout(function () {
+          el.textContent = word;
+          if (rtlSet.has(word)) {
+            el.setAttribute('dir', 'rtl');
+          } else {
+            el.removeAttribute('dir');
+          }
+          el.classList.remove('fade-out');
+        }, 600);
+      }
+
+      setInterval(next, delay);
+    })();
+  </script>
+
+</body>
+</html>

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ title }}</title>
+</head>
+<body>
+  <main>
+    <h1>{{ title }}</h1>
+    <p>Path: {{ path }}</p>
+  </main>
+</body>
+</html>

--- a/tests/Unit/Http/Controller/DiscoveryControllerTest.php
+++ b/tests/Unit/Http/Controller/DiscoveryControllerTest.php
@@ -18,7 +18,9 @@ use Giiken\Query\SearchResultSet;
 use Giiken\Query\SearchService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Inertia\InertiaResponse;
 
@@ -26,10 +28,15 @@ use Waaseyaa\Inertia\InertiaResponse;
 final class DiscoveryControllerTest extends TestCase
 {
     private DiscoveryController $controller;
+    /** @var SearchService&MockObject */
     private SearchService $searchService;
+    /** @var QaServiceInterface&MockObject */
     private QaServiceInterface $qaService;
+    /** @var CommunityRepositoryInterface&MockObject */
     private CommunityRepositoryInterface $communityRepo;
+    /** @var KnowledgeItemRepositoryInterface&MockObject */
     private KnowledgeItemRepositoryInterface $itemRepo;
+    private AccountInterface $account;
 
     protected function setUp(): void
     {
@@ -37,6 +44,7 @@ final class DiscoveryControllerTest extends TestCase
         $this->qaService = $this->createMock(QaServiceInterface::class);
         $this->communityRepo = $this->createMock(CommunityRepositoryInterface::class);
         $this->itemRepo = $this->createMock(KnowledgeItemRepositoryInterface::class);
+        $this->account = $this->createMock(AccountInterface::class);
 
         $this->controller = new DiscoveryController(
             $this->searchService,
@@ -53,7 +61,12 @@ final class DiscoveryControllerTest extends TestCase
         $this->communityRepo->method('findBySlug')->willReturn($community);
         $this->searchService->method('search')->willReturn(SearchResultSet::empty());
 
-        $response = $this->controller->index('test-community', null);
+        $response = $this->controller->index(
+            ['communitySlug' => 'test-community'],
+            [],
+            $this->account,
+            new HttpRequest(),
+        );
 
         self::assertInstanceOf(InertiaResponse::class, $response);
     }
@@ -71,7 +84,12 @@ final class DiscoveryControllerTest extends TestCase
         );
         $this->searchService->method('search')->willReturn($resultSet);
 
-        $response = $this->controller->search('test-community', 'test query', 1, null);
+        $response = $this->controller->search(
+            ['communitySlug' => 'test-community'],
+            ['query' => 'test query', 'page' => 1],
+            $this->account,
+            new HttpRequest(),
+        );
 
         self::assertInstanceOf(InertiaResponse::class, $response);
     }
@@ -86,7 +104,12 @@ final class DiscoveryControllerTest extends TestCase
         $this->qaService->method('ask')->willReturn($qaResponse);
         $this->searchService->method('search')->willReturn(SearchResultSet::empty());
 
-        $response = $this->controller->ask('test-community', 'What is this?', null);
+        $response = $this->controller->ask(
+            ['communitySlug' => 'test-community'],
+            ['question' => 'What is this?'],
+            $this->account,
+            new HttpRequest(),
+        );
 
         self::assertInstanceOf(InertiaResponse::class, $response);
     }
@@ -107,7 +130,12 @@ final class DiscoveryControllerTest extends TestCase
         ]);
         $this->itemRepo->method('find')->willReturn($item);
 
-        $response = $this->controller->show('test-community', '1', null);
+        $response = $this->controller->show(
+            ['communitySlug' => 'test-community', 'itemId' => '1'],
+            [],
+            $this->account,
+            new HttpRequest(),
+        );
 
         self::assertInstanceOf(InertiaResponse::class, $response);
     }

--- a/tests/Unit/Http/Controller/ManagementControllerTest.php
+++ b/tests/Unit/Http/Controller/ManagementControllerTest.php
@@ -6,44 +6,41 @@ namespace Giiken\Tests\Unit\Http\Controller;
 
 use Giiken\Entity\Community\Community;
 use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Export\ExportServiceInterface;
-use Giiken\Export\ImportServiceInterface;
 use Giiken\Http\Controller\ManagementController;
-use Giiken\Query\Report\ReportServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Inertia\InertiaResponse;
 
 #[CoversClass(ManagementController::class)]
 final class ManagementControllerTest extends TestCase
 {
     private ManagementController $controller;
+    /** @var CommunityRepositoryInterface&MockObject */
     private CommunityRepositoryInterface $communityRepo;
-    private ReportServiceInterface $reportService;
-    private ExportServiceInterface $exportService;
-    private ImportServiceInterface $importService;
+    private AccountInterface $account;
 
     protected function setUp(): void
     {
         $this->communityRepo = $this->createMock(CommunityRepositoryInterface::class);
-        $this->reportService = $this->createMock(ReportServiceInterface::class);
-        $this->exportService = $this->createMock(ExportServiceInterface::class);
-        $this->importService = $this->createMock(ImportServiceInterface::class);
+        $this->account = $this->createMock(AccountInterface::class);
 
-        $this->controller = new ManagementController(
-            $this->communityRepo,
-            $this->reportService,
-            $this->exportService,
-            $this->importService,
-        );
+        $this->controller = new ManagementController($this->communityRepo);
     }
 
     #[Test]
     public function dashboard_returns_inertia_response(): void
     {
         $this->communityRepo->method('findBySlug')->willReturn($this->makeCommunity());
-        $response = $this->controller->dashboard('test-community');
+        $response = $this->controller->dashboard(
+            ['communitySlug' => 'test-community'],
+            [],
+            $this->account,
+            new HttpRequest(),
+        );
         self::assertInstanceOf(InertiaResponse::class, $response);
     }
 
@@ -51,7 +48,12 @@ final class ManagementControllerTest extends TestCase
     public function reports_returns_inertia_response(): void
     {
         $this->communityRepo->method('findBySlug')->willReturn($this->makeCommunity());
-        $response = $this->controller->reports('test-community');
+        $response = $this->controller->reports(
+            ['communitySlug' => 'test-community'],
+            [],
+            $this->account,
+            new HttpRequest(),
+        );
         self::assertInstanceOf(InertiaResponse::class, $response);
     }
 
@@ -59,8 +61,51 @@ final class ManagementControllerTest extends TestCase
     public function export_page_returns_inertia_response(): void
     {
         $this->communityRepo->method('findBySlug')->willReturn($this->makeCommunity());
-        $response = $this->controller->exportPage('test-community');
+        $response = $this->controller->exportPage(
+            ['communitySlug' => 'test-community'],
+            [],
+            $this->account,
+            new HttpRequest(),
+        );
         self::assertInstanceOf(InertiaResponse::class, $response);
+    }
+
+    #[Test]
+    public function dashboard_returns_boot_error_when_services_are_not_configured(): void
+    {
+        $controller = new ManagementController();
+        $account = $this->createMock(AccountInterface::class);
+
+        $response = $controller->dashboard(
+            ['communitySlug' => 'test-community'],
+            [],
+            $account,
+            new HttpRequest(),
+        );
+
+        self::assertInstanceOf(InertiaResponse::class, $response);
+        self::assertArrayHasKey('community', $response->props);
+        self::assertNull($response->props['community']);
+        self::assertSame('Management services are not configured yet.', $response->props['bootError'] ?? null);
+    }
+
+    #[Test]
+    public function reports_returns_boot_error_when_services_are_not_configured(): void
+    {
+        $controller = new ManagementController();
+        $account = $this->createMock(AccountInterface::class);
+
+        $response = $controller->reports(
+            ['communitySlug' => 'test-community'],
+            [],
+            $account,
+            new HttpRequest(),
+        );
+
+        self::assertInstanceOf(InertiaResponse::class, $response);
+        self::assertArrayHasKey('community', $response->props);
+        self::assertNull($response->props['community']);
+        self::assertSame('Report services are not configured yet.', $response->props['bootError'] ?? null);
     }
 
     private function makeCommunity(): Community

--- a/tests/Unit/Http/Middleware/RequireStaffRoleTest.php
+++ b/tests/Unit/Http/Middleware/RequireStaffRoleTest.php
@@ -47,9 +47,15 @@ final class RequireStaffRoleTest extends TestCase
         self::assertFalse((new RequireStaffRole())->check(null, 'comm-1'));
     }
 
+    /**
+     * @param array<int, string> $roles
+     */
     private function makeAccount(array $roles): AccountInterface
     {
         return new class($roles) implements AccountInterface {
+            /**
+             * @param array<int, string> $roles
+             */
             public function __construct(private readonly array $roles) {}
             public function id(): int|string { return '1'; }
             public function getRoles(): array { return $this->roles; }

--- a/tests/Unit/Pipeline/CompilationPipelineTest.php
+++ b/tests/Unit/Pipeline/CompilationPipelineTest.php
@@ -52,6 +52,7 @@ final class CompilationPipelineTest extends TestCase
              */
             public function __construct(private array &$savedItems) {}
             public function find(string $id, ?string $langcode = null, bool $fallback = false): ?EntityInterface { return null; }
+            public function findMany(array $ids, ?string $langcode = null, bool $fallback = false): array { return []; }
             public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null): array { return []; }
             public function save(EntityInterface $entity, bool $validate = true): int { $this->savedItems[] = $entity; return 1; }
             public function delete(EntityInterface $entity): void {}
@@ -92,6 +93,7 @@ final class CompilationPipelineTest extends TestCase
         };
         $repo = new class implements EntityRepositoryInterface {
             public function find(string $id, ?string $langcode = null, bool $fallback = false): ?EntityInterface { return null; }
+            public function findMany(array $ids, ?string $langcode = null, bool $fallback = false): array { return []; }
             public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null): array { return []; }
             public function save(EntityInterface $entity, bool $validate = true): int { return 1; }
             public function delete(EntityInterface $entity): void {}

--- a/tests/Unit/Pipeline/Step/EmbedStepTest.php
+++ b/tests/Unit/Pipeline/Step/EmbedStepTest.php
@@ -41,6 +41,7 @@ final class EmbedStepTest extends TestCase
             /** @phpstan-ignore-next-line */
             public function __construct(private ?KnowledgeItem &$savedItem) {}
             public function find(string $id, ?string $langcode = null, bool $fallback = false): ?EntityInterface { return null; }
+            public function findMany(array $ids, ?string $langcode = null, bool $fallback = false): array { return []; }
             public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null): array { return []; }
             public function save(EntityInterface $entity, bool $validate = true): int { \assert($entity instanceof KnowledgeItem); $this->savedItem = $entity; return 1; }
             public function delete(EntityInterface $entity): void {}
@@ -84,6 +85,7 @@ final class EmbedStepTest extends TestCase
         };
         $repo = new class implements EntityRepositoryInterface {
             public function find(string $id, ?string $langcode = null, bool $fallback = false): ?EntityInterface { return null; }
+            public function findMany(array $ids, ?string $langcode = null, bool $fallback = false): array { return []; }
             public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null): array { return []; }
             public function save(EntityInterface $entity, bool $validate = true): int { return 1; }
             public function delete(EntityInterface $entity): void {}


### PR DESCRIPTION
## Summary

This PR updates Giiken to the current Waaseyaa alpha line, aligns HTTP/SSR controller signatures with the framework, and improves local DX.

### Framework / runtime
- `composer.lock`: waaseyaa/* and explicit `waaseyaa/ssr`; `symfony/dotenv`
- `public/index.php`: Dotenv load + `$response->send()` (skeleton parity)
- `DiscoveryController` / `ManagementController`: SSR dispatch args `($params, $query, $account, $httpRequest)`, nullable injected services with `bootError` when unwired
- `ManagementController` constructor now only accepts `CommunityRepositoryInterface` (report/export/import are not used in handlers yet)

### Tests
- `EntityRepositoryInterface` test stubs include `findMany`
- PHPUnit mocks documented with `&MockObject` for PHPStan
- Level-8 iterable types on controller params and middleware test helpers

### DX / governance
- `.env.example`, `.gitignore` for `.env` / `.env.local`
- `bin/waaseyaa` wrapper, `composer` scripts (`dev`, `test`, `analyse`)
- `templates/`: skeleton `home`, `page`, `404` Twig (`{{ title }}` uses `APP_NAME` via SSR context)
- `docs/architecture/lifecycle.md`, CI lifecycle drift check, `lefthook.yml`
- `CLAUDE.md` updates

### Paired upstream change
SSR fallback branding / `APP_NAME` handling in `RenderController`: **waaseyaa/framework#1173**. After that release, run `composer update waaseyaa/ssr` (vendor is gitignored; no vendored patches in this PR).

## Checklist
- [ ] Link project issue / milestone if required by Giiken workflow
- [x] PHPUnit + PHPStan pass locally (lefthook pre-push)


Made with [Cursor](https://cursor.com)