### PR TITLE
feat: Phase 0 boot — migrations, DI, seed, dev LLM/embed stubs (#40–#44)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4495,7 +4495,7 @@
         },
         {
             "name": "waaseyaa/access",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/access.git",
@@ -4537,13 +4537,13 @@
             "description": "Access control and permission system for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/access/issues",
-                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/admin-surface",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/admin-surface.git",
@@ -4591,13 +4591,13 @@
             "description": "Canonical integration boundary for the Waaseyaa Admin SPA",
             "support": {
                 "issues": "https://github.com/waaseyaa/admin-surface/issues",
-                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-09T00:23:33+00:00"
         },
         {
             "name": "waaseyaa/ai-agent",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-agent.git",
@@ -4636,7 +4636,7 @@
             "description": "AI agent orchestration and tool execution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-agent/issues",
-                "source": "https://github.com/waaseyaa/ai-agent/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/ai-agent/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
@@ -4693,7 +4693,7 @@
         },
         {
             "name": "waaseyaa/ai-schema",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-schema.git",
@@ -4731,13 +4731,13 @@
             "description": "AI-friendly schema definitions and entity metadata for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-schema/issues",
-                "source": "https://github.com/waaseyaa/ai-schema/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/ai-schema/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/ai-vector",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-vector.git",
@@ -4779,13 +4779,13 @@
             "description": "Vector embedding storage and similarity search for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-vector/issues",
-                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/api",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/api.git",
@@ -4832,13 +4832,13 @@
             "description": "RESTful JSON:API resource layer for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/api/issues",
-                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-09T02:45:12+00:00"
         },
         {
             "name": "waaseyaa/auth",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/auth.git",
@@ -4883,13 +4883,13 @@
             "description": "Headless authentication for Waaseyaa — login, registration, 2FA, password reset",
             "support": {
                 "issues": "https://github.com/waaseyaa/auth/issues",
-                "source": "https://github.com/waaseyaa/auth/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/auth/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T18:25:20+00:00"
         },
         {
             "name": "waaseyaa/cache",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cache.git",
@@ -4932,13 +4932,13 @@
             "description": "Cache bins with cache tag invalidation for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cache/issues",
-                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/cli",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cli.git",
@@ -4989,13 +4989,13 @@
             "description": "Command-line interface and console commands for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cli/issues",
-                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/config",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/config.git",
@@ -5034,13 +5034,13 @@
             "description": "Configuration management as YAML with package-aware ownership for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/config/issues",
-                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/core",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/core.git",
@@ -5090,13 +5090,13 @@
             "description": "Waaseyaa core engine — entities, fields, config, plugins, routing, access.",
             "support": {
                 "issues": "https://github.com/waaseyaa/core/issues",
-                "source": "https://github.com/waaseyaa/core/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/core/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-09T14:32:41+00:00"
         },
         {
             "name": "waaseyaa/database-legacy",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/database-legacy.git",
@@ -5134,13 +5134,13 @@
             "description": "Database adapter wrapping Drupal DBAL. Interim until Doctrine migration.",
             "support": {
                 "issues": "https://github.com/waaseyaa/database-legacy/issues",
-                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/entity",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity.git",
@@ -5186,13 +5186,13 @@
             "description": "Entity type system — types, interfaces, lifecycle, queries. No storage.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity/issues",
-                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-09T03:10:30+00:00"
         },
         {
             "name": "waaseyaa/entity-storage",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity-storage.git",
@@ -5234,13 +5234,13 @@
             "description": "Pluggable entity persistence. v0.1.0: SQL storage behind clean interfaces.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity-storage/issues",
-                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-09T13:06:20+00:00"
         },
         {
             "name": "waaseyaa/error-handler",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/error-handler.git",
@@ -5283,13 +5283,13 @@
             "description": "Rich exception pages, solution hints, and editor links for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/error-handler/issues",
-                "source": "https://github.com/waaseyaa/error-handler/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/error-handler/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T18:25:20+00:00"
         },
         {
             "name": "waaseyaa/field",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/field.git",
@@ -5329,22 +5329,22 @@
             "description": "Field type system — pluggable field types, definitions, formatters for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/field/issues",
-                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/foundation",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/foundation.git",
-                "reference": "ae0b5b71298f051dd18496ddbc67c5683cd89885"
+                "reference": "f8f93b3a203d12192b34fb6f7967974e1f914300"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/ae0b5b71298f051dd18496ddbc67c5683cd89885",
-                "reference": "ae0b5b71298f051dd18496ddbc67c5683cd89885",
+                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/f8f93b3a203d12192b34fb6f7967974e1f914300",
+                "reference": "f8f93b3a203d12192b34fb6f7967974e1f914300",
                 "shasum": ""
             },
             "require": {
@@ -5385,9 +5385,9 @@
             "description": "Core framework primitives: service providers, domain events, results, error handling",
             "support": {
                 "issues": "https://github.com/waaseyaa/foundation/issues",
-                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.116"
             },
-            "time": "2026-04-09T16:18:03+00:00"
+            "time": "2026-04-09T18:54:48+00:00"
         },
         {
             "name": "waaseyaa/i18n",
@@ -5435,7 +5435,7 @@
         },
         {
             "name": "waaseyaa/inertia",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/inertia.git",
@@ -5478,13 +5478,13 @@
             "description": "Server-side Inertia.js v3 protocol adapter for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/inertia/issues",
-                "source": "https://github.com/waaseyaa/inertia/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/inertia/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T16:57:28+00:00"
         },
         {
             "name": "waaseyaa/ingestion",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ingestion.git",
@@ -5523,13 +5523,13 @@
             "description": "Payload validation and ingestion utilities for Waaseyaa applications",
             "support": {
                 "issues": "https://github.com/waaseyaa/ingestion/issues",
-                "source": "https://github.com/waaseyaa/ingestion/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/ingestion/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/mail",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/mail.git",
@@ -5577,7 +5577,7 @@
             "description": "Transport-agnostic mail API for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/mail/issues",
-                "source": "https://github.com/waaseyaa/mail/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/mail/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-09T02:22:27+00:00"
         },
@@ -5636,7 +5636,7 @@
         },
         {
             "name": "waaseyaa/plugin",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/plugin.git",
@@ -5674,13 +5674,13 @@
             "description": "Attribute-based plugin discovery and management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/plugin/issues",
-                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/queue",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/queue.git",
@@ -5725,13 +5725,13 @@
             "description": "Asynchronous task queue and job processing for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/queue/issues",
-                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/relationship",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/relationship.git",
@@ -5773,13 +5773,13 @@
             "description": "Reusable relationship primitives for Waaseyaa applications",
             "support": {
                 "issues": "https://github.com/waaseyaa/relationship/issues",
-                "source": "https://github.com/waaseyaa/relationship/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/relationship/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-09T03:10:30+00:00"
         },
         {
             "name": "waaseyaa/routing",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/routing.git",
@@ -5820,13 +5820,13 @@
             "description": "HTTP routing and controller resolution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/routing/issues",
-                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/search",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/search.git",
@@ -5873,7 +5873,7 @@
             "description": "Search provider interface and DTOs for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/search/issues",
-                "source": "https://github.com/waaseyaa/search/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/search/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
@@ -5938,7 +5938,7 @@
         },
         {
             "name": "waaseyaa/state",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/state.git",
@@ -5976,13 +5976,13 @@
             "description": "Key-value state storage for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/state/issues",
-                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/taxonomy",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/taxonomy.git",
@@ -6026,13 +6026,13 @@
             "description": "Taxonomy vocabulary and term entity types for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/taxonomy/issues",
-                "source": "https://github.com/waaseyaa/taxonomy/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/taxonomy/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/testing",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/testing.git",
@@ -6068,13 +6068,13 @@
             "description": "Testing utilities for Waaseyaa — base test case, entity factories, and helper traits.",
             "support": {
                 "issues": "https://github.com/waaseyaa/testing/issues",
-                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         },
         {
             "name": "waaseyaa/typed-data",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/typed-data.git",
@@ -6112,13 +6112,13 @@
             "description": "Type system with PHP-native facade for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/typed-data/issues",
-                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/user",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/user.git",
@@ -6166,13 +6166,13 @@
             "description": "User entity, authentication, and session management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/user/issues",
-                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-09T02:22:27+00:00"
         },
         {
             "name": "waaseyaa/validation",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/validation.git",
@@ -6211,13 +6211,13 @@
             "description": "Data validation constraints and validators for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/validation/issues",
-                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:54:17+00:00"
         },
         {
             "name": "waaseyaa/workflows",
-            "version": "v0.1.0-alpha.115",
+            "version": "v0.1.0-alpha.116",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/workflows.git",
@@ -6262,7 +6262,7 @@
             "description": "Content moderation and editorial workflow states for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/workflows/issues",
-                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.115"
+                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.116"
             },
             "time": "2026-04-08T15:25:48+00:00"
         }

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -44,7 +44,14 @@ Inside `HttpKernel::handle()` -> `AbstractKernel::boot()`:
 The first Giiken app-level class in normal boot is `Giiken\GiikenServiceProvider`:
 
 - `register()` contributes app entity types (`community`, `knowledge_item`, `wiki_lint_report`)
+- `register()` binds app services resolved by SSR `serviceResolver`: `CommunityRepositoryInterface`, `KnowledgeItemRepositoryInterface`, `SearchService`, `QaServiceInterface`, dev `NullEmbeddingProvider` / `NullLlmProvider`, and a PSR-14 `EventDispatcherInterface` alias to the kernel dispatcher (for `EntityRepository` construction)
+- `commands()` contributes CLI commands (`giiken:seed:test-community`)
 - `routes()` contributes app HTTP routes
+
+### 1.4 Schema and local data
+
+- App SQL migrations live in `migrations/` and run via `bin/waaseyaa migrate` during bootstrap when pending.
+- Tables `community`, `knowledge_item`, and `wiki_lint_report` must exist before repository saves; optional demo data: `bin/waaseyaa giiken:seed:test-community` after migrate.
 
 ## 2. Request Lifecycle
 
@@ -106,11 +113,11 @@ Entity types are declared in `GiikenServiceProvider::register()` and attached to
 
 ### 3.2 Repository Access
 
-App repositories (community, knowledge items) wrap framework repository/storage APIs:
+App repositories (community, knowledge items) wrap `Waaseyaa\EntityStorage\EntityRepository` with `SqlStorageDriver` on the app database connection:
 
 - load entities
 - filter by community/slug
-- save/delete with timestamp conventions
+- save/delete with timestamp conventions; `KnowledgeItemRepository` optionally triggers `SearchIndexerInterface` (FTS) on save
 
 ### 3.3 Query + Pipeline Flow
 
@@ -163,7 +170,8 @@ Keep these true during refactoring:
 | Area | Likely Impact | Verify With |
 |---|---|---|
 | `public/index.php` | global boot and response emission | smoke test `/`, non-zero body |
-| `src/GiikenServiceProvider.php` | route/entity discovery | route smoke tests + boot |
+| `src/GiikenServiceProvider.php` | routes, entity types, DI bindings, CLI commands | route smoke tests + boot + `waaseyaa list` / migrate + seed |
+| `migrations/*.php` | SQLite schema for app entities | `bin/waaseyaa migrate` + repository integration |
 | `src/Http/Controller/*` | SSR dispatch and Inertia props | unit tests + route smoke tests |
 | `src/Entity/*` and repositories | data shape, persistence behavior | unit tests + integration tests |
 | `src/Query/*`, `src/Pipeline/*` | search/qa/compile behavior | unit tests for services and steps |

--- a/migrations/20260409_120000_create_giiken_entity_tables.php
+++ b/migrations/20260409_120000_create_giiken_entity_tables.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * Materialize Giiken content entity tables (matches SqlSchemaHandler content-entity layout).
+ */
+return new class extends Migration
+{
+    public function up(SchemaBuilder $schema): void
+    {
+        $conn = $schema->getConnection();
+
+        if (!$schema->hasTable('community')) {
+            $conn->executeStatement("
+                CREATE TABLE community (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    uuid VARCHAR(128) NOT NULL DEFAULT '',
+                    bundle VARCHAR(128) NOT NULL DEFAULT '',
+                    name VARCHAR(255) NOT NULL DEFAULT '',
+                    langcode VARCHAR(12) NOT NULL DEFAULT 'en',
+                    _data TEXT NOT NULL DEFAULT '{}'
+                )
+            ");
+            $conn->executeStatement('CREATE UNIQUE INDEX community_uuid ON community(uuid)');
+            $conn->executeStatement('CREATE INDEX community_bundle ON community(bundle)');
+        }
+
+        if (!$schema->hasTable('knowledge_item')) {
+            $conn->executeStatement("
+                CREATE TABLE knowledge_item (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    uuid VARCHAR(128) NOT NULL DEFAULT '',
+                    bundle VARCHAR(128) NOT NULL DEFAULT '',
+                    title VARCHAR(255) NOT NULL DEFAULT '',
+                    langcode VARCHAR(12) NOT NULL DEFAULT 'en',
+                    _data TEXT NOT NULL DEFAULT '{}'
+                )
+            ");
+            $conn->executeStatement('CREATE UNIQUE INDEX knowledge_item_uuid ON knowledge_item(uuid)');
+            $conn->executeStatement('CREATE INDEX knowledge_item_bundle ON knowledge_item(bundle)');
+        }
+
+        if (!$schema->hasTable('wiki_lint_report')) {
+            $conn->executeStatement("
+                CREATE TABLE wiki_lint_report (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    uuid VARCHAR(128) NOT NULL DEFAULT '',
+                    bundle VARCHAR(128) NOT NULL DEFAULT '',
+                    title VARCHAR(255) NOT NULL DEFAULT '',
+                    langcode VARCHAR(12) NOT NULL DEFAULT 'en',
+                    _data TEXT NOT NULL DEFAULT '{}'
+                )
+            ");
+            $conn->executeStatement('CREATE UNIQUE INDEX wiki_lint_report_uuid ON wiki_lint_report(uuid)');
+            $conn->executeStatement('CREATE INDEX wiki_lint_report_bundle ON wiki_lint_report(bundle)');
+        }
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        $schema->dropIfExists('wiki_lint_report');
+        $schema->dropIfExists('knowledge_item');
+        $schema->dropIfExists('community');
+    }
+};

--- a/migrations/20260409_121000_add_giiken_entity_field_columns.php
+++ b/migrations/20260409_121000_add_giiken_entity_field_columns.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Waaseyaa\Foundation\Migration\Migration;
+use Waaseyaa\Foundation\Migration\SchemaBuilder;
+
+/**
+ * EntityRepository + SqlStorageDriver persist every field in toArray() as real columns.
+ * Add columns for Giiken domain fields (extras are not auto-packed into _data yet).
+ */
+return new class extends Migration
+{
+    /** @var array<string, array<string, string>> table => column => SQL type/def */
+    private const COLUMNS = [
+        'community' => [
+            'slug'          => "VARCHAR(255) NOT NULL DEFAULT ''",
+            'wiki_schema'   => "TEXT NOT NULL DEFAULT '{}'",
+            'locale'        => "VARCHAR(12) NOT NULL DEFAULT 'en'",
+            'created_at'    => "TEXT NOT NULL DEFAULT ''",
+            'updated_at'    => "TEXT NOT NULL DEFAULT ''",
+            'sovereignty_profile' => "VARCHAR(32) NOT NULL DEFAULT 'local'",
+            'contact_email' => "VARCHAR(255) NOT NULL DEFAULT ''",
+        ],
+        'knowledge_item' => [
+            'community_id'   => "VARCHAR(128) NOT NULL DEFAULT ''",
+            'content'        => "TEXT NOT NULL DEFAULT ''",
+            'knowledge_type' => "VARCHAR(64) NOT NULL DEFAULT ''",
+            'access_tier'    => "VARCHAR(32) NOT NULL DEFAULT 'members'",
+            'created_at'     => "TEXT NOT NULL DEFAULT ''",
+            'updated_at'     => "TEXT NOT NULL DEFAULT ''",
+            'compiled_at'    => "TEXT NOT NULL DEFAULT ''",
+        ],
+        'wiki_lint_report' => [
+            'community_id' => "VARCHAR(128) NOT NULL DEFAULT ''",
+            'created_at'   => "TEXT NOT NULL DEFAULT ''",
+            'updated_at'   => "TEXT NOT NULL DEFAULT ''",
+        ],
+    ];
+
+    public function up(SchemaBuilder $schema): void
+    {
+        $conn = $schema->getConnection();
+
+        foreach (self::COLUMNS as $table => $columns) {
+            if (!$schema->hasTable($table)) {
+                continue;
+            }
+            foreach ($columns as $column => $definition) {
+                if ($schema->hasColumn($table, $column)) {
+                    continue;
+                }
+                $conn->executeStatement("ALTER TABLE {$table} ADD COLUMN {$column} {$definition}");
+            }
+        }
+    }
+
+    public function down(SchemaBuilder $schema): void
+    {
+        // SQLite cannot drop columns cleanly — no-op (dev databases: rebuild from scratch).
+    }
+};

--- a/src/Console/SeedTestCommunityCommand.php
+++ b/src/Console/SeedTestCommunityCommand.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Console;
+
+use Giiken\Entity\Community\Community;
+use Giiken\Entity\Community\CommunityRepositoryInterface;
+use Giiken\Entity\Community\WikiSchema;
+use Giiken\Entity\KnowledgeItem\AccessTier;
+use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Uid\Uuid;
+
+#[AsCommand(
+    name: 'giiken:seed:test-community',
+    description: 'Seed a demo community (slug test-community) with sample public knowledge items',
+)]
+final class SeedTestCommunityCommand extends Command
+{
+    public function __construct(
+        private readonly CommunityRepositoryInterface $communityRepo,
+        private readonly KnowledgeItemRepositoryInterface $itemRepo,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $existing = $this->communityRepo->findBySlug('test-community');
+        if ($existing !== null) {
+            $output->writeln('<comment>Community "test-community" already exists. Ensuring sample items only.</comment>');
+            $community = $existing;
+        } else {
+            $wiki = new WikiSchema(
+                defaultLanguage: 'en',
+                knowledgeTypes: array_map(
+                    static fn (KnowledgeType $t): string => $t->value,
+                    KnowledgeType::cases(),
+                ),
+                llmInstructions: 'Preserve community voice; cite sources; flag uncertainty.',
+            );
+
+            $community = new Community([
+                'uuid'          => Uuid::v4()->toRfc4122(),
+                'name'          => 'Test Community',
+                'bundle'        => 'community',
+                'slug'          => 'test-community',
+                'wiki_schema'   => json_encode($wiki->toArray(), JSON_THROW_ON_ERROR),
+            ]);
+            $community->enforceIsNew(true);
+            $this->communityRepo->save($community);
+
+            $community = $this->communityRepo->findBySlug('test-community');
+            if ($community === null) {
+                $output->writeln('<error>Failed to load community after save.</error>');
+
+                return Command::FAILURE;
+            }
+            $output->writeln('<info>Created community "test-community".</info>');
+        }
+
+        $communityId = (string) $community->get('id');
+        $items       = $this->itemRepo->findByCommunity($communityId);
+        if ($items !== []) {
+            $output->writeln(sprintf('<comment>Community already has %d knowledge items. Skip seeding items.</comment>', count($items)));
+
+            return Command::SUCCESS;
+        }
+
+        $samples = [
+            [
+                'title'   => 'Welcome to Giiken',
+                'content' => 'This is a seeded knowledge item for local development. Replace with real community knowledge.',
+                'type'    => KnowledgeType::Cultural,
+            ],
+            [
+                'title'   => 'Governance overview',
+                'content' => 'Sample governance note. Public tier so it appears for anonymous visitors in development.',
+                'type'    => KnowledgeType::Governance,
+            ],
+            [
+                'title'   => 'Land and territory',
+                'content' => 'Sample land reference. Use the ingestion pipeline to import real documents.',
+                'type'    => KnowledgeType::Land,
+            ],
+        ];
+
+        foreach ($samples as $row) {
+            $item = new KnowledgeItem([
+                'uuid'          => Uuid::v4()->toRfc4122(),
+                'title'         => $row['title'],
+                'bundle'        => 'knowledge_item',
+                'content'       => $row['content'],
+                'community_id'  => $communityId,
+                'knowledge_type'=> $row['type']->value,
+                'access_tier'   => AccessTier::Public->value,
+            ]);
+            $item->enforceIsNew(true);
+            $this->itemRepo->save($item);
+        }
+
+        $output->writeln(sprintf('<info>Seeded %d sample knowledge items.</info>', count($samples)));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Entity/KnowledgeItem/KnowledgeItem.php
+++ b/src/Entity/KnowledgeItem/KnowledgeItem.php
@@ -113,8 +113,8 @@ final class KnowledgeItem extends ContentEntityBase implements HasCommunity, Sea
     public function toSearchDocument(): array
     {
         return [
-            'title'   => $this->getTitle(),
-            'content' => $this->getContent(),
+            'title' => $this->getTitle(),
+            'body'  => $this->getContent(),
         ];
     }
 

--- a/src/GiikenServiceProvider.php
+++ b/src/GiikenServiceProvider.php
@@ -4,19 +4,43 @@ declare(strict_types=1);
 
 namespace Giiken;
 
+use Giiken\Access\KnowledgeItemAccessPolicy;
+use Giiken\Console\SeedTestCommunityCommand;
 use Giiken\Entity\Community\Community;
+use Giiken\Entity\Community\CommunityRepository;
+use Giiken\Entity\Community\CommunityRepositoryInterface;
 use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
+use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
 use Giiken\Http\Controller\DiscoveryController;
 use Giiken\Http\Controller\ManagementController;
+use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use Giiken\Pipeline\Provider\LlmProviderInterface;
+use Giiken\Pipeline\Provider\NullEmbeddingProvider;
+use Giiken\Pipeline\Provider\NullLlmProvider;
+use Giiken\Query\QaService;
+use Giiken\Query\QaServiceInterface;
+use Giiken\Query\SearchService;
 use Giiken\Wiki\WikiLintReport;
+use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 use Symfony\Component\Routing\Route;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherContract;
+use Waaseyaa\Database\DatabaseInterface;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\Connection\SingleConnectionResolver;
+use Waaseyaa\EntityStorage\Driver\SqlStorageDriver;
+use Waaseyaa\EntityStorage\EntityRepository as WaaseyaaEntityRepository;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Routing\WaaseyaaRouter;
+use Waaseyaa\Search\SearchIndexerInterface;
+use Waaseyaa\Search\SearchProviderInterface;
 
 final class GiikenServiceProvider extends ServiceProvider
 {
+    /** Single-segment paths that must not be treated as community slugs (framework routes, APIs). */
+    private const string COMMUNITY_SLUG_REQUIREMENT = '(?!admin$)(?!api$)[a-z0-9-]+';
+
     public function register(): void
     {
         $this->entityType(new EntityType(
@@ -51,6 +75,83 @@ final class GiikenServiceProvider extends ServiceProvider
                 'label' => 'title',
             ],
         ));
+
+        $this->singleton(PsrEventDispatcherInterface::class, function (): PsrEventDispatcherInterface {
+            $dispatcher = $this->resolve(SymfonyEventDispatcherContract::class);
+            if (!$dispatcher instanceof PsrEventDispatcherInterface) {
+                throw new \RuntimeException('Event dispatcher must implement Psr\\EventDispatcher\\EventDispatcherInterface.');
+            }
+
+            return $dispatcher;
+        });
+
+        $this->singleton(EmbeddingProviderInterface::class, static fn (): EmbeddingProviderInterface => new NullEmbeddingProvider());
+        $this->singleton(LlmProviderInterface::class, static fn (): LlmProviderInterface => new NullLlmProvider());
+        $this->singleton(KnowledgeItemAccessPolicy::class, static fn (): KnowledgeItemAccessPolicy => new KnowledgeItemAccessPolicy());
+
+        $this->singleton(CommunityRepositoryInterface::class, function (): CommunityRepositoryInterface {
+            $etm        = $this->resolve(EntityTypeManager::class);
+            $database   = $this->resolve(DatabaseInterface::class);
+            $dispatcher = $this->resolve(PsrEventDispatcherInterface::class);
+            $driver     = new SqlStorageDriver(new SingleConnectionResolver($database), 'id');
+            $entityRepo = new WaaseyaaEntityRepository(
+                $etm->getDefinition('community'),
+                $driver,
+                $dispatcher,
+                revisionDriver: null,
+                database: $database,
+            );
+
+            return new CommunityRepository($entityRepo);
+        });
+
+        $this->singleton(KnowledgeItemRepositoryInterface::class, function (): KnowledgeItemRepositoryInterface {
+            $etm        = $this->resolve(EntityTypeManager::class);
+            $database   = $this->resolve(DatabaseInterface::class);
+            $dispatcher = $this->resolve(PsrEventDispatcherInterface::class);
+            $driver     = new SqlStorageDriver(new SingleConnectionResolver($database), 'id');
+            $entityRepo = new WaaseyaaEntityRepository(
+                $etm->getDefinition('knowledge_item'),
+                $driver,
+                $dispatcher,
+                revisionDriver: null,
+                database: $database,
+            );
+
+            return new KnowledgeItemRepository(
+                $entityRepo,
+                $this->resolve(SearchIndexerInterface::class),
+            );
+        });
+
+        $this->singleton(SearchService::class, function (): SearchService {
+            return new SearchService(
+                $this->resolve(SearchProviderInterface::class),
+                $this->resolve(EmbeddingProviderInterface::class),
+                $this->resolve(KnowledgeItemAccessPolicy::class),
+                $this->resolve(KnowledgeItemRepositoryInterface::class),
+            );
+        });
+
+        $this->singleton(QaServiceInterface::class, function (): QaServiceInterface {
+            return new QaService(
+                $this->resolve(SearchService::class),
+                $this->resolve(LlmProviderInterface::class),
+            );
+        });
+    }
+
+    public function commands(
+        EntityTypeManager $entityTypeManager,
+        DatabaseInterface $database,
+        SymfonyEventDispatcherContract $dispatcher,
+    ): array {
+        return [
+            new SeedTestCommunityCommand(
+                $this->resolve(CommunityRepositoryInterface::class),
+                $this->resolve(KnowledgeItemRepositoryInterface::class),
+            ),
+        ];
     }
 
     public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
@@ -59,70 +160,56 @@ final class GiikenServiceProvider extends ServiceProvider
         $router->addRoute('giiken.discovery.index', new Route(
             '/{communitySlug}',
             ['_controller' => [DiscoveryController::class, 'index']],
-            ['communitySlug' => '[a-z0-9-]+'],
+            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
         ));
 
         $router->addRoute('giiken.discovery.search', new Route(
             '/{communitySlug}/search',
             ['_controller' => [DiscoveryController::class, 'search']],
-            ['communitySlug' => '[a-z0-9-]+'],
+            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
         ));
 
         $router->addRoute('giiken.discovery.ask', new Route(
             '/{communitySlug}/ask',
             ['_controller' => [DiscoveryController::class, 'ask']],
-            ['communitySlug' => '[a-z0-9-]+'],
+            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
         ));
 
         $router->addRoute('giiken.discovery.show', new Route(
             '/{communitySlug}/item/{itemId}',
             ['_controller' => [DiscoveryController::class, 'show']],
-            ['communitySlug' => '[a-z0-9-]+', 'itemId' => '.+'],
+            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT, 'itemId' => '.+'],
         ));
 
         // Management routes
         $router->addRoute('giiken.management.dashboard', new Route(
             '/{communitySlug}/manage',
             ['_controller' => [ManagementController::class, 'dashboard']],
-            ['communitySlug' => '[a-z0-9-]+'],
+            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
         ));
 
         $router->addRoute('giiken.management.reports', new Route(
             '/{communitySlug}/manage/reports',
             ['_controller' => [ManagementController::class, 'reports']],
-            ['communitySlug' => '[a-z0-9-]+'],
+            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
         ));
 
         $router->addRoute('giiken.management.users', new Route(
             '/{communitySlug}/manage/users',
             ['_controller' => [ManagementController::class, 'users']],
-            ['communitySlug' => '[a-z0-9-]+'],
+            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
         ));
 
         $router->addRoute('giiken.management.ingestion', new Route(
             '/{communitySlug}/manage/ingestion',
             ['_controller' => [ManagementController::class, 'ingestion']],
-            ['communitySlug' => '[a-z0-9-]+'],
+            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
         ));
 
         $router->addRoute('giiken.management.export', new Route(
             '/{communitySlug}/manage/export',
             ['_controller' => [ManagementController::class, 'exportPage']],
-            ['communitySlug' => '[a-z0-9-]+'],
+            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
         ));
     }
-
-    // Phase 2 ingestion handler wiring deferred until Waaseyaa DI container is ready.
-    // See docs/superpowers/plans/2026-04-04-ingestion-pipeline.md Task 7.
-
-    // Phase 3 service wiring — deferred until Waaseyaa DI container is ready:
-    //
-    // SearchService(Fts5SearchProvider, EmbeddingProviderInterface, KnowledgeItemAccessPolicy, KnowledgeItemRepositoryInterface)
-    // QaService(SearchService, LlmProviderInterface)
-    // ReportService([GovernanceSummaryReport, LanguageReport, LandBriefReport], KnowledgeItemRepositoryInterface)
-    // ExportService(KnowledgeItemRepositoryInterface, EmbeddingProviderInterface, FileRepositoryInterface)
-    // ImportService(CommunityRepositoryInterface, KnowledgeItemRepositoryInterface, FileRepositoryInterface)
-    // MediaIngestionHandler(FileRepositoryInterface, QueueInterface) -> register with IngestionHandlerRegistry
-    //
-    // KnowledgeItemRepository takes optional SearchIndexerInterface for FTS indexing on save.
 }

--- a/src/Pipeline/Provider/NullEmbeddingProvider.php
+++ b/src/Pipeline/Provider/NullEmbeddingProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Pipeline\Provider;
+
+/**
+ * Dev-friendly embedding + semantic search no-op (vector search returns no hits).
+ */
+final class NullEmbeddingProvider implements EmbeddingProviderInterface
+{
+    public function embed(string $text): array
+    {
+        return [];
+    }
+
+    public function search(string $query, string $communityId, int $limit = 5): array
+    {
+        return [];
+    }
+
+    public function store(string $entityId, string $text, string $communityId): void {}
+}

--- a/src/Pipeline/Provider/NullLlmProvider.php
+++ b/src/Pipeline/Provider/NullLlmProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Pipeline\Provider;
+
+/**
+ * Safe default LLM for local dev when no API keys or Ollama are configured.
+ */
+final class NullLlmProvider implements LlmProviderInterface
+{
+    public function complete(string $systemPrompt, string $userPrompt): string
+    {
+        return 'Configure a real LLM provider for production Q&A. '
+            . 'Stub response: see context lines above for [item-…] citations.';
+    }
+}

--- a/tests/Unit/Entity/KnowledgeItem/KnowledgeItemSearchIndexableTest.php
+++ b/tests/Unit/Entity/KnowledgeItem/KnowledgeItemSearchIndexableTest.php
@@ -31,12 +31,12 @@ final class KnowledgeItemSearchIndexableTest extends TestCase
     }
 
     #[Test]
-    public function to_search_document_returns_title_and_content(): void
+    public function to_search_document_returns_title_and_body_for_fts(): void
     {
         $item = $this->item();
         $doc = $item->toSearchDocument();
         $this->assertSame('Solar Panel Debate', $doc['title']);
-        $this->assertSame('Discussion about solar panels in Massey.', $doc['content']);
+        $this->assertSame('Discussion about solar panels in Massey.', $doc['body']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Ships **Phase 0: boot-to-browser** plumbing so Discovery/Management can resolve real services against SQLite: entity tables, `EntityRepository` + `SqlStorageDriver` repositories, FTS-backed `SearchService`, `QaService` with stub LLM, and a demo seed command.

## Changes

- **Migrations:** `community`, `knowledge_item`, `wiki_lint_report` base schema plus columns required because `EntityRepository` persists full `toArray()` rows (not only `_data`).
- **DI:** `GiikenServiceProvider` registers repositories, `SearchService`, `QaServiceInterface`, PSR-14 dispatcher bridge, `NullEmbeddingProvider` / `NullLlmProvider`; wires `Waaseyaa` search indexer + FTS provider.
- **CLI:** `bin/waaseyaa giiken:seed:test-community` (bundle `knowledge_item`).
- **Search:** `KnowledgeItem::toSearchDocument()` uses `body` for `Fts5SearchIndexer`; test updated.
- **Docs:** `docs/architecture/lifecycle.md` updated for hooks (migrations, bindings, seed).
- **Deps:** `composer.lock` — waaseyaa/* `alpha.115` → `alpha.116`.

## How to verify

```bash
composer install
./vendor/bin/phpunit
./vendor/bin/phpstan analyse src
php bin/waaseyaa migrate
php bin/waaseyaa giiken:seed:test-community
```

## Issues

Closes #40  
Closes #42  
Closes #43  
Closes #44  

Does **not** close #41 (session auth / login UX — follow-up).

Made with [Cursor](https://cursor.com)