### PR TITLE
feat: Phase 0 session login, management auth, Inertia HTTP bridge

### DIFF
--- a/config/waaseyaa.php
+++ b/config/waaseyaa.php
@@ -2,6 +2,17 @@
 
 declare(strict_types=1);
 
+$projectRoot = dirname(__DIR__);
+$dbEnv = getenv('WAASEYAA_DB');
+$database = null;
+if (\is_string($dbEnv) && $dbEnv !== '') {
+    if (str_starts_with($dbEnv, '/') || str_starts_with($dbEnv, ':')) {
+        $database = $dbEnv;
+    } else {
+        $database = $projectRoot . '/' . ltrim($dbEnv, './');
+    }
+}
+
 return [
     'debug' => filter_var(getenv('APP_DEBUG') ?: false, FILTER_VALIDATE_BOOLEAN),
 
@@ -9,7 +20,7 @@ return [
 
     'environment' => getenv('APP_ENV') ?: 'production',
 
-    'database' => null,
+    'database' => $database,
 
     'config_dir' => getenv('WAASEYAA_CONFIG_DIR') ?: __DIR__ . '/sync',
 

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -44,14 +44,14 @@ Inside `HttpKernel::handle()` -> `AbstractKernel::boot()`:
 The first Giiken app-level class in normal boot is `Giiken\GiikenServiceProvider`:
 
 - `register()` contributes app entity types (`community`, `knowledge_item`, `wiki_lint_report`)
-- `register()` binds app services resolved by SSR `serviceResolver`: `CommunityRepositoryInterface`, `KnowledgeItemRepositoryInterface`, `SearchService`, `QaServiceInterface`, dev `NullEmbeddingProvider` / `NullLlmProvider`, and a PSR-14 `EventDispatcherInterface` alias to the kernel dispatcher (for `EntityRepository` construction)
+- `register()` binds app services resolved by SSR `serviceResolver`: `CommunityRepositoryInterface`, `KnowledgeItemRepositoryInterface`, `SearchService`, `QaServiceInterface`, dev `NullEmbeddingProvider` / `NullLlmProvider`, and a PSR-14 `EventDispatcherInterface` alias to the kernel dispatcher (for `EntityRepository` construction); registers `Giiken\Http\Inertia\InertiaHttpResponder` (full-page renderer from DI when present)
 - `commands()` contributes CLI commands (`giiken:seed:test-community`)
-- `routes()` contributes app HTTP routes
+- `routes()` contributes app HTTP routes (discovery, management, `GET`/`POST` `/login`, `GET` `/logout`)
 
 ### 1.4 Schema and local data
 
 - App SQL migrations live in `migrations/` and run via `bin/waaseyaa migrate` during bootstrap when pending.
-- Tables `community`, `knowledge_item`, and `wiki_lint_report` must exist before repository saves; optional demo data: `bin/waaseyaa giiken:seed:test-community` after migrate.
+- Tables `community`, `knowledge_item`, and `wiki_lint_report` must exist before repository saves; optional demo data: `bin/waaseyaa giiken:seed:test-community` after migrate (also ensures demo `giiken_staff` user and community staff role when `EntityTypeManager` is available).
 
 ## 2. Request Lifecycle
 
@@ -70,18 +70,20 @@ After boot, `HttpKernel::serveHttpRequest()` executes:
    - debug headers (if debug mode)
    - provider middleware
 5. Account resolution (`_account` request attribute)
-6. Router dispatch (`ControllerDispatcher`)
+6. If the middleware pipeline returns a response whose status is **not** **200** (for example **302** login redirect or **401** JSON from `AuthorizationMiddleware`), the kernel returns it immediately and does not dispatch controllers. (Shipped in `waaseyaa/foundation` as of [framework#1180](https://github.com/waaseyaa/framework/pull/1180); bump Giiken’s lockfile after that release.)
+7. Router dispatch (`ControllerDispatcher`)
 
 ### 2.2 App Route Registration
 
 App routes are added through `GiikenServiceProvider::routes(...)`, including:
 
+- Session HTML auth (public): `GET`/`POST` `/login`, `GET` `/logout`
 - Discovery:
   - `/{communitySlug}`
   - `/{communitySlug}/search`
   - `/{communitySlug}/ask`
   - `/{communitySlug}/item/{itemId}`
-- Management:
+- Management (`_authenticated`):
   - `/{communitySlug}/manage`
   - `/{communitySlug}/manage/reports`
   - `/{communitySlug}/manage/users`
@@ -90,10 +92,10 @@ App routes are added through `GiikenServiceProvider::routes(...)`, including:
 
 ### 2.3 Controller Dispatch Contract
 
-Current app controllers use the SSR dispatch signature:
+SSR app controllers use the four-argument dispatch shape; they return **`Symfony\Component\HttpFoundation\Response`**, not raw `InertiaResponse`, so `SsrPageHandler` can emit HTML or JSON. Internally they call `Inertia::render(...)` and pass the result through `InertiaHttpResponder::toResponse()`.
 
 ```php
-public function action(array $params, array $query, AccountInterface $account, HttpRequest $request): InertiaResponse
+public function action(array $params, array $query, AccountInterface $account, HttpRequest $request): Response
 ```
 
 Symfony `HttpRequest` remains the dispatcher’s fourth argument. Inside the handler, build
@@ -160,7 +162,7 @@ Primary extension points for app work:
 Keep these true during refactoring:
 
 1. `public/index.php` always sends the response (`$response->send()`).
-2. Controllers keep the active dispatch signature expected by SSR dispatch.
+2. Controllers keep the active SSR dispatch signature (`array $params`, `array $query`, `AccountInterface`, `HttpRequest`) and return `Response`.
 3. Optional service dependencies are handled with explicit guard returns (no implicit null behavior).
 4. `GiikenServiceProvider` remains the single source of app route/entity registration.
 5. Boot-time failures remain deterministic and observable (log + stable error response path).

--- a/src/Console/SeedTestCommunityCommand.php
+++ b/src/Console/SeedTestCommunityCommand.php
@@ -12,6 +12,8 @@ use Giiken\Entity\KnowledgeItem\KnowledgeItem;
 use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
 use Giiken\Entity\KnowledgeItem\KnowledgeType;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\User\User;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -26,6 +28,7 @@ final class SeedTestCommunityCommand extends Command
     public function __construct(
         private readonly CommunityRepositoryInterface $communityRepo,
         private readonly KnowledgeItemRepositoryInterface $itemRepo,
+        private readonly EntityTypeManager $entityTypeManager,
     ) {
         parent::__construct();
     }
@@ -66,7 +69,9 @@ final class SeedTestCommunityCommand extends Command
         }
 
         $communityId = (string) $community->get('id');
-        $items       = $this->itemRepo->findByCommunity($communityId);
+        $this->ensureStaffUser($communityId, $output);
+
+        $items = $this->itemRepo->findByCommunity($communityId);
         if ($items !== []) {
             $output->writeln(sprintf('<comment>Community already has %d knowledge items. Skip seeding items.</comment>', count($items)));
 
@@ -108,5 +113,48 @@ final class SeedTestCommunityCommand extends Command
         $output->writeln(sprintf('<info>Seeded %d sample knowledge items.</info>', count($samples)));
 
         return Command::SUCCESS;
+    }
+
+    private function ensureStaffUser(string $communityId, OutputInterface $output): void
+    {
+        $storage = $this->entityTypeManager->getStorage('user');
+        $role = 'giiken.community.' . $communityId . '.staff';
+        $password = getenv('GIIKEN_SEED_STAFF_PASSWORD');
+        if (!\is_string($password) || $password === '') {
+            $password = 'giiken-dev';
+        }
+
+        $ids = $storage->getQuery()
+            ->condition('name', 'giiken_staff')
+            ->range(0, 1)
+            ->execute();
+
+        if ($ids !== []) {
+            $loaded = $storage->load(reset($ids));
+            if (!$loaded instanceof User) {
+                return;
+            }
+            if (!\in_array($role, $loaded->getRoles(), true)) {
+                $loaded->addRole($role);
+                $storage->save($loaded);
+                $output->writeln('<info>Added community staff role to user "giiken_staff".</info>');
+            }
+
+            return;
+        }
+
+        $user = new User([
+            'name'           => 'giiken_staff',
+            'mail'           => 'staff@giiken.local',
+            'status'         => 1,
+            'email_verified' => 1,
+            'roles'          => ['authenticated', $role],
+        ]);
+        $user->setRawPassword($password);
+        $user->enforceIsNew();
+        $storage->save($user);
+
+        $output->writeln('<info>Created user "giiken_staff" with community staff role.</info>');
+        $output->writeln('<comment>Password: GIIKEN_SEED_STAFF_PASSWORD env or default "giiken-dev".</comment>');
     }
 }

--- a/src/GiikenServiceProvider.php
+++ b/src/GiikenServiceProvider.php
@@ -14,6 +14,9 @@ use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
 use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
 use Giiken\Http\Controller\DiscoveryController;
 use Giiken\Http\Controller\ManagementController;
+use Giiken\Http\Controller\WebLoginController;
+use Giiken\Http\Controller\WebLogoutController;
+use Giiken\Http\Inertia\InertiaHttpResponder;
 use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
 use Giiken\Pipeline\Provider\LlmProviderInterface;
 use Giiken\Pipeline\Provider\NullEmbeddingProvider;
@@ -23,7 +26,6 @@ use Giiken\Query\QaServiceInterface;
 use Giiken\Query\SearchService;
 use Giiken\Wiki\WikiLintReport;
 use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
-use Symfony\Component\Routing\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherContract;
 use Waaseyaa\Database\DatabaseInterface;
 use Waaseyaa\Entity\EntityType;
@@ -31,18 +33,32 @@ use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\EntityStorage\Connection\SingleConnectionResolver;
 use Waaseyaa\EntityStorage\Driver\SqlStorageDriver;
 use Waaseyaa\EntityStorage\EntityRepository as WaaseyaaEntityRepository;
+use Waaseyaa\Foundation\Http\Inertia\InertiaFullPageRendererInterface;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Routing\RouteBuilder;
 use Waaseyaa\Routing\WaaseyaaRouter;
 use Waaseyaa\Search\SearchIndexerInterface;
 use Waaseyaa\Search\SearchProviderInterface;
 
 final class GiikenServiceProvider extends ServiceProvider
 {
-    /** Single-segment paths that must not be treated as community slugs (framework routes, APIs). */
-    private const string COMMUNITY_SLUG_REQUIREMENT = '(?!admin$)(?!api$)[a-z0-9-]+';
+    /**
+     * Single-segment paths that must not be treated as community slugs (framework routes, APIs, auth).
+     */
+    private const string COMMUNITY_SLUG_REQUIREMENT = '(?!admin$)(?!api$)(?!login$)(?!logout$)[a-z0-9-]+';
 
     public function register(): void
     {
+        $this->singleton(InertiaHttpResponder::class, function (): InertiaHttpResponder {
+            try {
+                $renderer = $this->resolve(InertiaFullPageRendererInterface::class);
+            } catch (\Throwable) {
+                $renderer = null;
+            }
+
+            return new InertiaHttpResponder($renderer, $this->config);
+        });
+
         $this->entityType(new EntityType(
             id: 'community',
             label: 'Community',
@@ -150,66 +166,143 @@ final class GiikenServiceProvider extends ServiceProvider
             new SeedTestCommunityCommand(
                 $this->resolve(CommunityRepositoryInterface::class),
                 $this->resolve(KnowledgeItemRepositoryInterface::class),
+                $entityTypeManager,
             ),
         ];
     }
 
     public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
     {
-        // Discovery routes
-        $router->addRoute('giiken.discovery.index', new Route(
-            '/{communitySlug}',
-            ['_controller' => [DiscoveryController::class, 'index']],
-            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
-        ));
+        $router->addRoute(
+            'giiken.login',
+            RouteBuilder::create('/login')
+                ->controller(WebLoginController::class . '::showForm')
+                ->methods('GET')
+                ->allowAll()
+                ->render()
+                ->build(),
+        );
 
-        $router->addRoute('giiken.discovery.search', new Route(
-            '/{communitySlug}/search',
-            ['_controller' => [DiscoveryController::class, 'search']],
-            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
-        ));
+        $router->addRoute(
+            'giiken.login.submit',
+            RouteBuilder::create('/login')
+                ->controller(WebLoginController::class . '::submit')
+                ->methods('POST')
+                ->allowAll()
+                ->render()
+                ->build(),
+        );
 
-        $router->addRoute('giiken.discovery.ask', new Route(
-            '/{communitySlug}/ask',
-            ['_controller' => [DiscoveryController::class, 'ask']],
-            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
-        ));
+        $router->addRoute(
+            'giiken.logout',
+            RouteBuilder::create('/logout')
+                ->controller(WebLogoutController::class . '::logout')
+                ->methods('GET')
+                ->allowAll()
+                ->render()
+                ->build(),
+        );
 
-        $router->addRoute('giiken.discovery.show', new Route(
-            '/{communitySlug}/item/{itemId}',
-            ['_controller' => [DiscoveryController::class, 'show']],
-            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT, 'itemId' => '.+'],
-        ));
+        // Discovery routes (public)
+        $router->addRoute(
+            'giiken.discovery.index',
+            RouteBuilder::create('/{communitySlug}')
+                ->controller(DiscoveryController::class . '::index')
+                ->requirement('communitySlug', self::COMMUNITY_SLUG_REQUIREMENT)
+                ->methods('GET')
+                ->allowAll()
+                ->render()
+                ->build(),
+        );
 
-        // Management routes
-        $router->addRoute('giiken.management.dashboard', new Route(
-            '/{communitySlug}/manage',
-            ['_controller' => [ManagementController::class, 'dashboard']],
-            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
-        ));
+        $router->addRoute(
+            'giiken.discovery.search',
+            RouteBuilder::create('/{communitySlug}/search')
+                ->controller(DiscoveryController::class . '::search')
+                ->requirement('communitySlug', self::COMMUNITY_SLUG_REQUIREMENT)
+                ->methods('GET')
+                ->allowAll()
+                ->render()
+                ->build(),
+        );
 
-        $router->addRoute('giiken.management.reports', new Route(
-            '/{communitySlug}/manage/reports',
-            ['_controller' => [ManagementController::class, 'reports']],
-            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
-        ));
+        $router->addRoute(
+            'giiken.discovery.ask',
+            RouteBuilder::create('/{communitySlug}/ask')
+                ->controller(DiscoveryController::class . '::ask')
+                ->requirement('communitySlug', self::COMMUNITY_SLUG_REQUIREMENT)
+                ->methods('GET')
+                ->allowAll()
+                ->render()
+                ->build(),
+        );
 
-        $router->addRoute('giiken.management.users', new Route(
-            '/{communitySlug}/manage/users',
-            ['_controller' => [ManagementController::class, 'users']],
-            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
-        ));
+        $router->addRoute(
+            'giiken.discovery.show',
+            RouteBuilder::create('/{communitySlug}/item/{itemId}')
+                ->controller(DiscoveryController::class . '::show')
+                ->requirement('communitySlug', self::COMMUNITY_SLUG_REQUIREMENT)
+                ->requirement('itemId', '.+')
+                ->methods('GET')
+                ->allowAll()
+                ->render()
+                ->build(),
+        );
 
-        $router->addRoute('giiken.management.ingestion', new Route(
-            '/{communitySlug}/manage/ingestion',
-            ['_controller' => [ManagementController::class, 'ingestion']],
-            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
-        ));
+        // Management routes (session-authenticated)
+        $router->addRoute(
+            'giiken.management.dashboard',
+            RouteBuilder::create('/{communitySlug}/manage')
+                ->controller(ManagementController::class . '::dashboard')
+                ->requirement('communitySlug', self::COMMUNITY_SLUG_REQUIREMENT)
+                ->methods('GET')
+                ->requireAuthentication()
+                ->render()
+                ->build(),
+        );
 
-        $router->addRoute('giiken.management.export', new Route(
-            '/{communitySlug}/manage/export',
-            ['_controller' => [ManagementController::class, 'exportPage']],
-            ['communitySlug' => self::COMMUNITY_SLUG_REQUIREMENT],
-        ));
+        $router->addRoute(
+            'giiken.management.reports',
+            RouteBuilder::create('/{communitySlug}/manage/reports')
+                ->controller(ManagementController::class . '::reports')
+                ->requirement('communitySlug', self::COMMUNITY_SLUG_REQUIREMENT)
+                ->methods('GET')
+                ->requireAuthentication()
+                ->render()
+                ->build(),
+        );
+
+        $router->addRoute(
+            'giiken.management.users',
+            RouteBuilder::create('/{communitySlug}/manage/users')
+                ->controller(ManagementController::class . '::users')
+                ->requirement('communitySlug', self::COMMUNITY_SLUG_REQUIREMENT)
+                ->methods('GET')
+                ->requireAuthentication()
+                ->render()
+                ->build(),
+        );
+
+        $router->addRoute(
+            'giiken.management.ingestion',
+            RouteBuilder::create('/{communitySlug}/manage/ingestion')
+                ->controller(ManagementController::class . '::ingestion')
+                ->requirement('communitySlug', self::COMMUNITY_SLUG_REQUIREMENT)
+                ->methods('GET')
+                ->requireAuthentication()
+                ->render()
+                ->build(),
+        );
+
+        $router->addRoute(
+            'giiken.management.export',
+            RouteBuilder::create('/{communitySlug}/manage/export')
+                ->controller(ManagementController::class . '::exportPage')
+                ->requirement('communitySlug', self::COMMUNITY_SLUG_REQUIREMENT)
+                ->methods('GET')
+                ->requireAuthentication()
+                ->render()
+                ->build(),
+        );
     }
 }

--- a/src/Http/Controller/DiscoveryController.php
+++ b/src/Http/Controller/DiscoveryController.php
@@ -7,15 +7,16 @@ namespace Giiken\Http\Controller;
 use Giiken\Entity\Community\Community;
 use Giiken\Entity\Community\CommunityRepositoryInterface;
 use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use Giiken\Http\Inertia\InertiaHttpResponder;
 use Giiken\Query\QaServiceInterface;
 use Giiken\Query\SearchQuery;
 use Giiken\Query\SearchResultSet;
 use Giiken\Query\SearchService;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Foundation\Http\Inbound\InboundHttpRequest;
 use Waaseyaa\Inertia\Inertia;
-use Waaseyaa\Inertia\InertiaResponse;
 
 final class DiscoveryController
 {
@@ -24,23 +25,24 @@ final class DiscoveryController
         private readonly ?QaServiceInterface $qaService = null,
         private readonly ?CommunityRepositoryInterface $communityRepo = null,
         private readonly ?KnowledgeItemRepositoryInterface $itemRepo = null,
+        private readonly ?InertiaHttpResponder $inertiaHttp = null,
     ) {}
 
     /**
      * @param array<string, mixed> $params
      * @param array<string, mixed> $query
      */
-    public function index(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
+    public function index(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): Response
     {
         $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
         $communitySlug = (string) $inbound->routeParam('communitySlug', '');
 
         if ($this->searchService === null || $this->communityRepo === null) {
-            return Inertia::render('Discovery/Index', [
+            return $this->page('Discovery/Index', [
                 'community' => null,
                 'recentItems' => $this->emptyResultSet(),
                 'bootError' => 'Discovery services are not configured yet.',
-            ]);
+            ], $httpRequest, $account);
         }
 
         $searchService = $this->searchService;
@@ -48,10 +50,10 @@ final class DiscoveryController
 
         $community = $communityRepo->findBySlug($communitySlug);
         if ($community === null) {
-            return Inertia::render('Discovery/Index', [
+            return $this->page('Discovery/Index', [
                 'community' => null,
                 'recentItems' => $this->emptyResultSet(),
-            ]);
+            ], $httpRequest, $account);
         }
 
         $recent = $searchService->search(
@@ -59,10 +61,10 @@ final class DiscoveryController
             $account,
         );
 
-        return Inertia::render('Discovery/Index', [
+        return $this->page('Discovery/Index', [
             'community' => $this->serializeCommunity($community),
             'recentItems' => $this->serializeResultSet($recent),
-        ]);
+        ], $httpRequest, $account);
     }
 
     /**
@@ -74,18 +76,18 @@ final class DiscoveryController
         array $query,
         AccountInterface $account,
         HttpRequest $httpRequest,
-    ): InertiaResponse {
+    ): Response {
         if ($this->searchService === null || $this->communityRepo === null) {
             $searchQuery = (string) ($query['query'] ?? '');
             $page = max(1, (int) ($query['page'] ?? 1));
 
-            return Inertia::render('Discovery/Search', [
+            return $this->page('Discovery/Search', [
                 'community' => null,
                 'query' => $searchQuery,
                 'results' => $this->emptyResultSet(),
                 'page' => $page,
                 'bootError' => 'Search services are not configured yet.',
-            ]);
+            ], $httpRequest, $account);
         }
 
         $searchService = $this->searchService;
@@ -98,12 +100,12 @@ final class DiscoveryController
 
         $community = $communityRepo->findBySlug($communitySlug);
         if ($community === null) {
-            return Inertia::render('Discovery/Search', [
+            return $this->page('Discovery/Search', [
                 'community' => null,
                 'query' => $searchQuery,
                 'results' => $this->emptyResultSet(),
                 'page' => $page,
-            ]);
+            ], $httpRequest, $account);
         }
 
         $results = $searchService->search(
@@ -115,24 +117,24 @@ final class DiscoveryController
             $account,
         );
 
-        return Inertia::render('Discovery/Search', [
+        return $this->page('Discovery/Search', [
             'community' => $this->serializeCommunity($community),
             'query' => $searchQuery,
             'results' => $this->serializeResultSet($results),
             'page' => $page,
-        ]);
+        ], $httpRequest, $account);
     }
 
     /**
      * @param array<string, mixed> $params
      * @param array<string, mixed> $query
      */
-    public function ask(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
+    public function ask(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): Response
     {
         if ($this->searchService === null || $this->qaService === null || $this->communityRepo === null) {
             $question = (string) ($query['question'] ?? '');
 
-            return Inertia::render('Discovery/Ask', [
+            return $this->page('Discovery/Ask', [
                 'community' => null,
                 'question' => $question,
                 'answer' => '',
@@ -140,7 +142,7 @@ final class DiscoveryController
                 'noRelevantItems' => true,
                 'relatedItems' => $this->emptyResultSet(),
                 'bootError' => 'Q&A services are not configured yet.',
-            ]);
+            ], $httpRequest, $account);
         }
 
         $searchService = $this->searchService;
@@ -153,14 +155,14 @@ final class DiscoveryController
 
         $community = $communityRepo->findBySlug($communitySlug);
         if ($community === null) {
-            return Inertia::render('Discovery/Ask', [
+            return $this->page('Discovery/Ask', [
                 'community' => null,
                 'question' => $question,
                 'answer' => '',
                 'citedItemIds' => [],
                 'noRelevantItems' => true,
                 'relatedItems' => $this->emptyResultSet(),
-            ]);
+            ], $httpRequest, $account);
         }
         $communityId = (string) $community->get('id');
 
@@ -171,28 +173,28 @@ final class DiscoveryController
             $account,
         );
 
-        return Inertia::render('Discovery/Ask', [
+        return $this->page('Discovery/Ask', [
             'community' => $this->serializeCommunity($community),
             'question' => $question,
             'answer' => $qaResponse->answer,
             'citedItemIds' => $qaResponse->citedItemIds,
             'noRelevantItems' => $qaResponse->noRelevantItems,
             'relatedItems' => $this->serializeResultSet($related),
-        ]);
+        ], $httpRequest, $account);
     }
 
     /**
      * @param array<string, mixed> $params
      * @param array<string, mixed> $query
      */
-    public function show(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
+    public function show(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): Response
     {
         if ($this->communityRepo === null || $this->itemRepo === null) {
-            return Inertia::render('Discovery/Show', [
+            return $this->page('Discovery/Show', [
                 'community' => null,
                 'item' => null,
                 'bootError' => 'Knowledge item services are not configured yet.',
-            ]);
+            ], $httpRequest, $account);
         }
 
         $communityRepo = $this->communityRepo;
@@ -205,13 +207,13 @@ final class DiscoveryController
         $community = $communityRepo->findBySlug($communitySlug);
         $item = $itemRepo->find($itemId);
         if ($community === null || $item === null) {
-            return Inertia::render('Discovery/Show', [
+            return $this->page('Discovery/Show', [
                 'community' => $community !== null ? $this->serializeCommunity($community) : null,
                 'item' => null,
-            ]);
+            ], $httpRequest, $account);
         }
 
-        return Inertia::render('Discovery/Show', [
+        return $this->page('Discovery/Show', [
             'community' => $this->serializeCommunity($community),
             'item' => [
                 'id' => $item->get('id'),
@@ -223,7 +225,25 @@ final class DiscoveryController
                 'createdAt' => $item->getCreatedAt(),
                 'updatedAt' => $item->getUpdatedAt(),
             ],
-        ]);
+        ], $httpRequest, $account);
+    }
+
+    /**
+     * @param array<string, mixed> $props
+     */
+    private function page(string $component, array $props, HttpRequest $httpRequest, AccountInterface $account): Response
+    {
+        if ($this->inertiaHttp === null) {
+            return new Response('Giiken: InertiaHttpResponder is not registered.', 500, [
+                'Content-Type' => 'text/plain; charset=UTF-8',
+            ]);
+        }
+
+        return $this->inertiaHttp->toResponse(
+            Inertia::render($component, $props),
+            $httpRequest,
+            $account,
+        );
     }
 
     /**

--- a/src/Http/Controller/ManagementController.php
+++ b/src/Http/Controller/ManagementController.php
@@ -6,128 +6,153 @@ namespace Giiken\Http\Controller;
 
 use Giiken\Entity\Community\Community;
 use Giiken\Entity\Community\CommunityRepositoryInterface;
+use Giiken\Http\Inertia\InertiaHttpResponder;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Foundation\Http\Inbound\InboundHttpRequest;
 use Waaseyaa\Inertia\Inertia;
-use Waaseyaa\Inertia\InertiaResponse;
 
 final class ManagementController
 {
     public function __construct(
         private readonly ?CommunityRepositoryInterface $communityRepo = null,
+        private readonly ?InertiaHttpResponder $inertiaHttp = null,
     ) {}
 
     /**
      * @param array<string, mixed> $params
      * @param array<string, mixed> $query
      */
-    public function dashboard(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
+    public function dashboard(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): Response
     {
         if ($this->communityRepo === null) {
-            return Inertia::render('Management/Dashboard', [
+            return $this->page('Management/Dashboard', [
                 'community' => null,
                 'bootError' => 'Management services are not configured yet.',
-            ]);
+            ], $httpRequest, $account);
         }
 
         $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
         $communitySlug = (string) $inbound->routeParam('communitySlug', '');
         $community = $this->communityRepo->findBySlug($communitySlug);
-        return Inertia::render('Management/Dashboard', [
+
+        return $this->page('Management/Dashboard', [
             'community' => $community !== null ? $this->serializeCommunity($community) : null,
             'bootError' => null,
-        ]);
+        ], $httpRequest, $account);
     }
 
     /**
      * @param array<string, mixed> $params
      * @param array<string, mixed> $query
      */
-    public function reports(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
+    public function reports(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): Response
     {
         if ($this->communityRepo === null) {
-            return Inertia::render('Management/Reports', [
+            return $this->page('Management/Reports', [
                 'community' => null,
                 'reportTypes' => ['governance_summary', 'language_report', 'land_brief'],
                 'bootError' => 'Report services are not configured yet.',
-            ]);
+            ], $httpRequest, $account);
         }
 
         $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
         $communitySlug = (string) $inbound->routeParam('communitySlug', '');
         $community = $this->communityRepo->findBySlug($communitySlug);
-        return Inertia::render('Management/Reports', [
+
+        return $this->page('Management/Reports', [
             'community'   => $community !== null ? $this->serializeCommunity($community) : null,
             'reportTypes' => ['governance_summary', 'language_report', 'land_brief'],
             'bootError' => null,
-        ]);
+        ], $httpRequest, $account);
     }
 
     /**
      * @param array<string, mixed> $params
      * @param array<string, mixed> $query
      */
-    public function users(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
+    public function users(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): Response
     {
         if ($this->communityRepo === null) {
-            return Inertia::render('Management/Users', [
+            return $this->page('Management/Users', [
                 'community' => null,
                 'bootError' => 'User services are not configured yet.',
-            ]);
+            ], $httpRequest, $account);
         }
 
         $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
         $communitySlug = (string) $inbound->routeParam('communitySlug', '');
         $community = $this->communityRepo->findBySlug($communitySlug);
-        return Inertia::render('Management/Users', [
+
+        return $this->page('Management/Users', [
             'community' => $community !== null ? $this->serializeCommunity($community) : null,
             'bootError' => null,
-        ]);
+        ], $httpRequest, $account);
     }
 
     /**
      * @param array<string, mixed> $params
      * @param array<string, mixed> $query
      */
-    public function ingestion(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
+    public function ingestion(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): Response
     {
         if ($this->communityRepo === null) {
-            return Inertia::render('Management/Ingestion', [
+            return $this->page('Management/Ingestion', [
                 'community' => null,
                 'bootError' => 'Ingestion services are not configured yet.',
-            ]);
+            ], $httpRequest, $account);
         }
 
         $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
         $communitySlug = (string) $inbound->routeParam('communitySlug', '');
         $community = $this->communityRepo->findBySlug($communitySlug);
-        return Inertia::render('Management/Ingestion', [
+
+        return $this->page('Management/Ingestion', [
             'community' => $community !== null ? $this->serializeCommunity($community) : null,
             'bootError' => null,
-        ]);
+        ], $httpRequest, $account);
     }
 
     /**
      * @param array<string, mixed> $params
      * @param array<string, mixed> $query
      */
-    public function exportPage(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): InertiaResponse
+    public function exportPage(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): Response
     {
         if ($this->communityRepo === null) {
-            return Inertia::render('Management/Export', [
+            return $this->page('Management/Export', [
                 'community' => null,
                 'bootError' => 'Export/import services are not configured yet.',
-            ]);
+            ], $httpRequest, $account);
         }
 
         $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
         $communitySlug = (string) $inbound->routeParam('communitySlug', '');
         $community = $this->communityRepo->findBySlug($communitySlug);
-        return Inertia::render('Management/Export', [
+
+        return $this->page('Management/Export', [
             'community' => $community !== null ? $this->serializeCommunity($community) : null,
             'bootError' => null,
-        ]);
+        ], $httpRequest, $account);
+    }
+
+    /**
+     * @param array<string, mixed> $props
+     */
+    private function page(string $component, array $props, HttpRequest $httpRequest, AccountInterface $account): Response
+    {
+        if ($this->inertiaHttp === null) {
+            return new Response('Giiken: InertiaHttpResponder is not registered.', 500, [
+                'Content-Type' => 'text/plain; charset=UTF-8',
+            ]);
+        }
+
+        return $this->inertiaHttp->toResponse(
+            Inertia::render($component, $props),
+            $httpRequest,
+            $account,
+        );
     }
 
     /**

--- a/src/Http/Controller/WebLoginController.php
+++ b/src/Http/Controller/WebLoginController.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Http\Controller;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\User\Http\AuthController;
+use Waaseyaa\User\Middleware\CsrfMiddleware;
+
+final class WebLoginController
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly Environment $twig,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function showForm(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): Response
+    {
+        $redirectRaw = $query['redirect'] ?? '';
+        $redirect = \is_string($redirectRaw) ? $redirectRaw : '';
+        $errorRaw = $query['error'] ?? '';
+        $error = \is_string($errorRaw) ? $errorRaw : '';
+
+        $html = $this->twig->render('login.html.twig', [
+            'redirect'        => $this->safeRedirectTarget($redirect),
+            'error'           => $error,
+            'alreadySignedIn' => $account->isAuthenticated(),
+        ]);
+
+        return new Response($html, 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function submit(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): Response
+    {
+        $username = trim((string) $httpRequest->request->get('username', ''));
+        $password = (string) $httpRequest->request->get('password', '');
+        $redirectRaw = (string) $httpRequest->request->get('redirect', '');
+        $safeRedirect = $this->safeRedirectTarget($redirectRaw);
+
+        if ($username === '' || $password === '') {
+            return new RedirectResponse(
+                '/login?redirect=' . rawurlencode($safeRedirect) . '&error=missing',
+                302,
+            );
+        }
+
+        $storage = $this->entityTypeManager->getStorage('user');
+        $user = (new AuthController())->findUserByName($storage, $username);
+
+        if ($user === null || !$user->isActive() || !$user->checkPassword($password)) {
+            return new RedirectResponse(
+                '/login?redirect=' . rawurlencode($safeRedirect) . '&error=invalid',
+                302,
+            );
+        }
+
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            return new Response(
+                'Session is not available; login cannot complete.',
+                500,
+                ['Content-Type' => 'text/plain; charset=UTF-8'],
+            );
+        }
+
+        $_SESSION['waaseyaa_uid'] = $user->id();
+        session_regenerate_id(true);
+        CsrfMiddleware::regenerate();
+
+        return new RedirectResponse($safeRedirect, 302);
+    }
+
+    private function safeRedirectTarget(string $redirect): string
+    {
+        if ($redirect === '' || !str_starts_with($redirect, '/') || str_starts_with($redirect, '//')) {
+            return '/';
+        }
+
+        return $redirect;
+    }
+}

--- a/src/Http/Controller/WebLogoutController.php
+++ b/src/Http/Controller/WebLogoutController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Http\Controller;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\AccountInterface;
+
+final class WebLogoutController
+{
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function logout(array $params, array $query, AccountInterface $account, HttpRequest $httpRequest): Response
+    {
+        if (session_status() === \PHP_SESSION_ACTIVE) {
+            $_SESSION = [];
+            session_regenerate_id(true);
+            session_destroy();
+        }
+
+        return new RedirectResponse('/', 302);
+    }
+}

--- a/src/Http/Inertia/InertiaHttpResponder.php
+++ b/src/Http/Inertia/InertiaHttpResponder.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Http\Inertia;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Cache\CacheConfigResolver;
+use Waaseyaa\Foundation\Http\Inertia\InertiaFullPageRendererInterface;
+use Waaseyaa\Foundation\Http\JsonApiResponseTrait;
+use Waaseyaa\Inertia\InertiaResponse;
+
+/**
+ * Bridges {@see InertiaResponse} to Symfony HTTP responses for {@see \Waaseyaa\SSR\SsrPageHandler}
+ * app-controller dispatch (which only handles {@see Response} today).
+ */
+final class InertiaHttpResponder
+{
+    use JsonApiResponseTrait;
+
+    /**
+     * @param array<string, mixed> $appConfig Kernel config (for {@see CacheConfigResolver}).
+     */
+    public function __construct(
+        private readonly ?InertiaFullPageRendererInterface $fullPageRenderer,
+        private readonly array $appConfig = [],
+    ) {}
+
+    public function toResponse(
+        InertiaResponse $page,
+        HttpRequest $request,
+        AccountInterface $account,
+    ): Response {
+        if ($this->fullPageRenderer === null) {
+            return $this->jsonApiResponse(500, [
+                'jsonapi' => ['version' => '1.1'],
+                'errors' => [[
+                    'status' => '500',
+                    'title' => 'Internal Server Error',
+                    'detail' => 'Inertia full-page renderer is not configured.',
+                ]],
+            ]);
+        }
+
+        $pageObject = $page->toPageObject();
+        $pageObject['url'] = $request->getRequestUri();
+
+        if ($request->headers->get('X-Inertia') === 'true') {
+            return $this->jsonApiResponse(200, $pageObject, [
+                'X-Inertia' => 'true',
+                'Vary' => 'X-Inertia',
+            ]);
+        }
+
+        $html = $this->fullPageRenderer->render($pageObject);
+        $response = new Response(
+            $html,
+            200,
+            ['Content-Type' => 'text/html; charset=UTF-8'],
+        );
+
+        $cache = new CacheConfigResolver($this->appConfig);
+        $maxAge = $cache->resolveRenderCacheMaxAge();
+        $response->headers->set(
+            'Cache-Control',
+            $cache->cacheControlHeaderForRender($account, $maxAge),
+        );
+
+        return $response;
+    }
+}

--- a/templates/login.html.twig
+++ b/templates/login.html.twig
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sign in — Giiken</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: system-ui, sans-serif;
+      background: #0a0a0a;
+      color: #fafafa;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      -webkit-font-smoothing: antialiased;
+    }
+    .panel {
+      width: 100%;
+      max-width: 400px;
+      padding: 2rem;
+      background: #141414;
+      border: 1px solid #2a2a2a;
+      border-radius: 12px;
+    }
+    h1 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem; }
+    p.sub { color: #a3a3a3; font-size: 0.9rem; margin-bottom: 1.5rem; line-height: 1.5; }
+    label { display: block; font-size: 0.8rem; color: #a3a3a3; margin-bottom: 0.35rem; }
+    input[type="text"], input[type="password"] {
+      width: 100%;
+      padding: 0.65rem 0.75rem;
+      border-radius: 8px;
+      border: 1px solid #333;
+      background: #0a0a0a;
+      color: #fafafa;
+      margin-bottom: 1rem;
+    }
+    input:focus { outline: 2px solid #ca8a04; border-color: #ca8a04; }
+    button {
+      width: 100%;
+      padding: 0.75rem 1rem;
+      border: none;
+      border-radius: 8px;
+      background: #ca8a04;
+      color: #0a0a0a;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    button:hover { filter: brightness(1.05); }
+    .banner {
+      padding: 0.75rem 1rem;
+      border-radius: 8px;
+      margin-bottom: 1rem;
+      font-size: 0.9rem;
+    }
+    .banner-error { background: #450a0a; color: #fecaca; border: 1px solid #7f1d1d; }
+    .banner-info { background: #1e293b; color: #bae6fd; border: 1px solid #334155; }
+    .foot { margin-top: 1.25rem; font-size: 0.85rem; color: #737373; }
+    .foot a { color: #ca8a04; text-decoration: none; }
+    .foot a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <main class="panel">
+    <h1>Sign in</h1>
+    <p class="sub">Use your Giiken account to open community management.</p>
+
+    {% if alreadySignedIn %}
+      <div class="banner banner-info">You are already signed in.</div>
+    {% endif %}
+
+    {% if error == 'invalid' %}
+      <div class="banner banner-error">Those credentials did not match an active account.</div>
+    {% elseif error == 'missing' %}
+      <div class="banner banner-error">Enter both username and password.</div>
+    {% endif %}
+
+    <form method="post" action="/login">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <input type="hidden" name="redirect" value="{{ redirect }}">
+
+      <label for="username">Username or email</label>
+      <input id="username" name="username" type="text" autocomplete="username" required>
+
+      <label for="password">Password</label>
+      <input id="password" name="password" type="password" autocomplete="current-password" required>
+
+      <button type="submit">Sign in</button>
+    </form>
+
+    <p class="foot"><a href="/">Back to home</a> · <a href="/logout">Sign out</a></p>
+  </main>
+</body>
+</html>

--- a/tests/Unit/Http/Controller/DiscoveryControllerTest.php
+++ b/tests/Unit/Http/Controller/DiscoveryControllerTest.php
@@ -10,6 +10,7 @@ use Giiken\Entity\KnowledgeItem\KnowledgeItem;
 use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
 use Giiken\Entity\KnowledgeItem\KnowledgeType;
 use Giiken\Http\Controller\DiscoveryController;
+use Giiken\Http\Inertia\InertiaHttpResponder;
 use Giiken\Query\QaResponse;
 use Giiken\Query\QaServiceInterface;
 use Giiken\Query\SearchQuery;
@@ -21,8 +22,9 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Access\AccountInterface;
-use Waaseyaa\Inertia\InertiaResponse;
+use Waaseyaa\Foundation\Http\Inertia\InertiaFullPageRendererInterface;
 
 #[CoversClass(DiscoveryController::class)]
 final class DiscoveryControllerTest extends TestCase
@@ -51,7 +53,31 @@ final class DiscoveryControllerTest extends TestCase
             $this->qaService,
             $this->communityRepo,
             $this->itemRepo,
+            $this->createInertiaResponder(),
         );
+    }
+
+    private function createInertiaResponder(): InertiaHttpResponder
+    {
+        $renderer = $this->createStub(InertiaFullPageRendererInterface::class);
+        $renderer->method('render')->willReturnCallback(
+            static fn (array $pageObject): string => json_encode($pageObject, JSON_THROW_ON_ERROR),
+        );
+
+        return new InertiaHttpResponder($renderer, []);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodePage(Response $response): array
+    {
+        $raw = $response->getContent();
+        self::assertIsString($raw);
+        $data = json_decode($raw, true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+
+        return $data;
     }
 
     #[Test]
@@ -68,7 +94,10 @@ final class DiscoveryControllerTest extends TestCase
             new HttpRequest(),
         );
 
-        self::assertInstanceOf(InertiaResponse::class, $response);
+        self::assertInstanceOf(Response::class, $response);
+        $page = $this->decodePage($response);
+        self::assertSame('Discovery/Index', $page['component']);
+        self::assertIsArray($page['props']['community'] ?? null);
     }
 
     #[Test]
@@ -91,7 +120,10 @@ final class DiscoveryControllerTest extends TestCase
             new HttpRequest(),
         );
 
-        self::assertInstanceOf(InertiaResponse::class, $response);
+        self::assertInstanceOf(Response::class, $response);
+        $page = $this->decodePage($response);
+        self::assertSame('Discovery/Search', $page['component']);
+        self::assertSame(1, $page['props']['results']['totalHits'] ?? null);
     }
 
     #[Test]
@@ -111,7 +143,10 @@ final class DiscoveryControllerTest extends TestCase
             new HttpRequest(),
         );
 
-        self::assertInstanceOf(InertiaResponse::class, $response);
+        self::assertInstanceOf(Response::class, $response);
+        $page = $this->decodePage($response);
+        self::assertSame('Discovery/Ask', $page['component']);
+        self::assertSame('The answer', $page['props']['answer'] ?? null);
     }
 
     #[Test]
@@ -137,7 +172,10 @@ final class DiscoveryControllerTest extends TestCase
             new HttpRequest(),
         );
 
-        self::assertInstanceOf(InertiaResponse::class, $response);
+        self::assertInstanceOf(Response::class, $response);
+        $page = $this->decodePage($response);
+        self::assertSame('Discovery/Show', $page['component']);
+        self::assertSame('Test Item', $page['props']['item']['title'] ?? null);
     }
 
     private function makeCommunity(): Community

--- a/tests/Unit/Http/Controller/ManagementControllerTest.php
+++ b/tests/Unit/Http/Controller/ManagementControllerTest.php
@@ -7,13 +7,15 @@ namespace Giiken\Tests\Unit\Http\Controller;
 use Giiken\Entity\Community\Community;
 use Giiken\Entity\Community\CommunityRepositoryInterface;
 use Giiken\Http\Controller\ManagementController;
+use Giiken\Http\Inertia\InertiaHttpResponder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Access\AccountInterface;
-use Waaseyaa\Inertia\InertiaResponse;
+use Waaseyaa\Foundation\Http\Inertia\InertiaFullPageRendererInterface;
 
 #[CoversClass(ManagementController::class)]
 final class ManagementControllerTest extends TestCase
@@ -28,7 +30,33 @@ final class ManagementControllerTest extends TestCase
         $this->communityRepo = $this->createMock(CommunityRepositoryInterface::class);
         $this->account = $this->createMock(AccountInterface::class);
 
-        $this->controller = new ManagementController($this->communityRepo);
+        $this->controller = new ManagementController(
+            $this->communityRepo,
+            $this->createInertiaResponder(),
+        );
+    }
+
+    private function createInertiaResponder(): InertiaHttpResponder
+    {
+        $renderer = $this->createStub(InertiaFullPageRendererInterface::class);
+        $renderer->method('render')->willReturnCallback(
+            static fn (array $pageObject): string => json_encode($pageObject, JSON_THROW_ON_ERROR),
+        );
+
+        return new InertiaHttpResponder($renderer, []);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodePage(Response $response): array
+    {
+        $raw = $response->getContent();
+        self::assertIsString($raw);
+        $data = json_decode($raw, true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+
+        return $data;
     }
 
     #[Test]
@@ -41,7 +69,9 @@ final class ManagementControllerTest extends TestCase
             $this->account,
             new HttpRequest(),
         );
-        self::assertInstanceOf(InertiaResponse::class, $response);
+        self::assertInstanceOf(Response::class, $response);
+        $page = $this->decodePage($response);
+        self::assertSame('Management/Dashboard', $page['component']);
     }
 
     #[Test]
@@ -54,7 +84,9 @@ final class ManagementControllerTest extends TestCase
             $this->account,
             new HttpRequest(),
         );
-        self::assertInstanceOf(InertiaResponse::class, $response);
+        self::assertInstanceOf(Response::class, $response);
+        $page = $this->decodePage($response);
+        self::assertSame('Management/Reports', $page['component']);
     }
 
     #[Test]
@@ -67,13 +99,15 @@ final class ManagementControllerTest extends TestCase
             $this->account,
             new HttpRequest(),
         );
-        self::assertInstanceOf(InertiaResponse::class, $response);
+        self::assertInstanceOf(Response::class, $response);
+        $page = $this->decodePage($response);
+        self::assertSame('Management/Export', $page['component']);
     }
 
     #[Test]
     public function dashboard_returns_boot_error_when_services_are_not_configured(): void
     {
-        $controller = new ManagementController();
+        $controller = new ManagementController(null, $this->createInertiaResponder());
         $account = $this->createMock(AccountInterface::class);
 
         $response = $controller->dashboard(
@@ -83,16 +117,17 @@ final class ManagementControllerTest extends TestCase
             new HttpRequest(),
         );
 
-        self::assertInstanceOf(InertiaResponse::class, $response);
-        self::assertArrayHasKey('community', $response->props);
-        self::assertNull($response->props['community']);
-        self::assertSame('Management services are not configured yet.', $response->props['bootError'] ?? null);
+        self::assertInstanceOf(Response::class, $response);
+        $page = $this->decodePage($response);
+        self::assertArrayHasKey('community', $page['props']);
+        self::assertNull($page['props']['community']);
+        self::assertSame('Management services are not configured yet.', $page['props']['bootError'] ?? null);
     }
 
     #[Test]
     public function reports_returns_boot_error_when_services_are_not_configured(): void
     {
-        $controller = new ManagementController();
+        $controller = new ManagementController(null, $this->createInertiaResponder());
         $account = $this->createMock(AccountInterface::class);
 
         $response = $controller->reports(
@@ -102,10 +137,11 @@ final class ManagementControllerTest extends TestCase
             new HttpRequest(),
         );
 
-        self::assertInstanceOf(InertiaResponse::class, $response);
-        self::assertArrayHasKey('community', $response->props);
-        self::assertNull($response->props['community']);
-        self::assertSame('Report services are not configured yet.', $response->props['bootError'] ?? null);
+        self::assertInstanceOf(Response::class, $response);
+        $page = $this->decodePage($response);
+        self::assertArrayHasKey('community', $page['props']);
+        self::assertNull($page['props']['community']);
+        self::assertSame('Report services are not configured yet.', $page['props']['bootError'] ?? null);
     }
 
     private function makeCommunity(): Community


### PR DESCRIPTION
## Summary

Implements session-based HTML login for Giiken management routes, bridges Inertia pages to Symfony responses for SSR dispatch, improves local DB path resolution, extends the test-community seed command, and documents the request lifecycle.

## Dependencies

**Merge [waaseyaa/framework#1180](https://github.com/waaseyaa/framework/pull/1180) first** (or tag a `waaseyaa/foundation` release that includes the HttpKernel fix). Without it, `AuthorizationMiddleware` 302/401 responses are dropped and `/{slug}/manage` stays reachable anonymously.

After the framework release: `composer update waaseyaa/foundation` (or full `composer update 'waaseyaa/*'`) and commit the lockfile if desired.

## Changes

- `GET`/`POST` `/login`, `GET` `/logout` with Twig + CSRF; `WebLoginController` / `WebLogoutController`
- `InertiaHttpResponder` + discovery/management controllers return `Response`
- Relative `WAASEYAA_DB` resolved under project root
- Seed command: `giiken_staff` user + community staff role
- Route tweaks (login/logout not treated as community slugs)
- Unit test updates; `docs/architecture/lifecycle.md` updated

## Testing

- `./vendor/bin/phpunit`
- `composer analyse` (PHPStan level 8)
- Manual: anonymous `GET /{community}/manage` → 302 to `/login?redirect=...` (with framework #1180)


Made with [Cursor](https://cursor.com)