### PR TITLE
feat: Phase 3 query layer (Q&A API, reports, export, synthesis)

### DIFF
--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -44,7 +44,7 @@ Inside `HttpKernel::handle()` -> `AbstractKernel::boot()`:
 The first Giiken app-level class in normal boot is `Giiken\GiikenServiceProvider`:
 
 - `register()` contributes app entity types (`community`, `knowledge_item`, `wiki_lint_report`)
-- `register()` binds app services resolved by SSR `serviceResolver`: `CommunityRepositoryInterface`, `KnowledgeItemRepositoryInterface`, `SearchService`, `QaServiceInterface`, dev `NullEmbeddingProvider` / `NullLlmProvider`, and a PSR-14 `EventDispatcherInterface` alias to the kernel dispatcher (for `EntityRepository` construction); registers `Giiken\Http\Inertia\InertiaHttpResponder` (full-page renderer from DI when present)
+- `register()` binds app services resolved by SSR `serviceResolver`: `CommunityRepositoryInterface`, `KnowledgeItemRepositoryInterface`, `SearchService`, `QaServiceInterface`, `ReportServiceInterface`, `ExportServiceInterface`, `SynthesisService`, dev `NullEmbeddingProvider` / `NullLlmProvider`, and a PSR-14 `EventDispatcherInterface` alias to the kernel dispatcher (for `EntityRepository` construction); registers `Giiken\Http\Inertia\InertiaHttpResponder` (full-page renderer from DI when present)
 - `commands()` contributes CLI commands (`giiken:seed:test-community`)
 - `routes()` contributes app HTTP routes (discovery, management, `GET`/`POST` `/login`, `GET` `/logout`)
 
@@ -83,12 +83,17 @@ App routes are added through `GiikenServiceProvider::routes(...)`, including:
   - `/{communitySlug}/search`
   - `/{communitySlug}/ask`
   - `/{communitySlug}/item/{itemId}`
+- Query API (JSON, CSRF-exempt; `POST` bodies are JSON):
+  - `POST /api/v1/ask` (`_public`) — Q&A + structured citations
+  - `POST /api/v1/report` (`_authenticated`) — markdown report + item count
+  - `POST /api/v1/synthesis` (`_authenticated`) — save Q&A answer as `knowledge_type: synthesis` with capped access
 - Management (`_authenticated`):
   - `/{communitySlug}/manage`
   - `/{communitySlug}/manage/reports`
   - `/{communitySlug}/manage/users`
   - `/{communitySlug}/manage/ingestion`
-  - `/{communitySlug}/manage/export`
+  - `/{communitySlug}/manage/export` (Inertia)
+  - `GET /{communitySlug}/manage/export/download` — ZIP export (admin-only; enforced in `ExportService`)
 
 ### 2.3 Controller Dispatch Contract
 

--- a/src/Entity/KnowledgeItem/KnowledgeType.php
+++ b/src/Entity/KnowledgeItem/KnowledgeType.php
@@ -11,4 +11,6 @@ enum KnowledgeType: string
     case Land         = 'land';
     case Relationship = 'relationship';
     case Event        = 'event';
+    /** Q&A or compiled synthesis saved back to the wiki (Phase 3). */
+    case Synthesis = 'synthesis';
 }

--- a/src/GiikenServiceProvider.php
+++ b/src/GiikenServiceProvider.php
@@ -12,8 +12,11 @@ use Giiken\Entity\Community\CommunityRepositoryInterface;
 use Giiken\Entity\KnowledgeItem\KnowledgeItem;
 use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
 use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use Giiken\Export\ExportService;
+use Giiken\Export\ExportServiceInterface;
 use Giiken\Http\Controller\DiscoveryController;
 use Giiken\Http\Controller\ManagementController;
+use Giiken\Http\Controller\QueryApiController;
 use Giiken\Http\Controller\WebLoginController;
 use Giiken\Http\Controller\WebLogoutController;
 use Giiken\Http\Inertia\InertiaHttpResponder;
@@ -23,7 +26,13 @@ use Giiken\Pipeline\Provider\NullEmbeddingProvider;
 use Giiken\Pipeline\Provider\NullLlmProvider;
 use Giiken\Query\QaService;
 use Giiken\Query\QaServiceInterface;
+use Giiken\Query\Report\GovernanceSummaryReport;
+use Giiken\Query\Report\LandBriefReport;
+use Giiken\Query\Report\LanguageReport;
+use Giiken\Query\Report\ReportService;
+use Giiken\Query\Report\ReportServiceInterface;
 use Giiken\Query\SearchService;
+use Giiken\Query\SynthesisService;
 use Giiken\Wiki\WikiLintReport;
 use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherContract;
@@ -155,6 +164,29 @@ final class GiikenServiceProvider extends ServiceProvider
                 $this->resolve(LlmProviderInterface::class),
             );
         });
+
+        $this->singleton(ReportServiceInterface::class, function (): ReportServiceInterface {
+            return new ReportService(
+                [
+                    new GovernanceSummaryReport(),
+                    new LanguageReport(),
+                    new LandBriefReport(),
+                ],
+                $this->resolve(KnowledgeItemRepositoryInterface::class),
+                $this->resolve(KnowledgeItemAccessPolicy::class),
+            );
+        });
+
+        $this->singleton(ExportServiceInterface::class, function (): ExportServiceInterface {
+            return new ExportService($this->resolve(KnowledgeItemRepositoryInterface::class));
+        });
+
+        $this->singleton(SynthesisService::class, function (): SynthesisService {
+            return new SynthesisService(
+                $this->resolve(KnowledgeItemRepositoryInterface::class),
+                $this->resolve(KnowledgeItemAccessPolicy::class),
+            );
+        });
     }
 
     public function commands(
@@ -249,6 +281,39 @@ final class GiikenServiceProvider extends ServiceProvider
                 ->build(),
         );
 
+        $router->addRoute(
+            'giiken.api.v1.ask',
+            RouteBuilder::create('/api/v1/ask')
+                ->controller(QueryApiController::class . '::ask')
+                ->methods('POST')
+                ->jsonApi()
+                ->csrfExempt()
+                ->allowAll()
+                ->build(),
+        );
+
+        $router->addRoute(
+            'giiken.api.v1.report',
+            RouteBuilder::create('/api/v1/report')
+                ->controller(QueryApiController::class . '::report')
+                ->methods('POST')
+                ->jsonApi()
+                ->csrfExempt()
+                ->requireAuthentication()
+                ->build(),
+        );
+
+        $router->addRoute(
+            'giiken.api.v1.synthesis',
+            RouteBuilder::create('/api/v1/synthesis')
+                ->controller(QueryApiController::class . '::saveSynthesis')
+                ->methods('POST')
+                ->jsonApi()
+                ->csrfExempt()
+                ->requireAuthentication()
+                ->build(),
+        );
+
         // Management routes (session-authenticated)
         $router->addRoute(
             'giiken.management.dashboard',
@@ -291,6 +356,16 @@ final class GiikenServiceProvider extends ServiceProvider
                 ->methods('GET')
                 ->requireAuthentication()
                 ->render()
+                ->build(),
+        );
+
+        $router->addRoute(
+            'giiken.management.export.download',
+            RouteBuilder::create('/{communitySlug}/manage/export/download')
+                ->controller(ManagementController::class . '::exportDownload')
+                ->requirement('communitySlug', self::COMMUNITY_SLUG_REQUIREMENT)
+                ->methods('GET')
+                ->requireAuthentication()
                 ->build(),
         );
 

--- a/src/Http/Controller/DiscoveryController.php
+++ b/src/Http/Controller/DiscoveryController.php
@@ -139,6 +139,7 @@ final class DiscoveryController
                 'question' => $question,
                 'answer' => '',
                 'citedItemIds' => [],
+                'citations' => [],
                 'noRelevantItems' => true,
                 'relatedItems' => $this->emptyResultSet(),
                 'bootError' => 'Q&A services are not configured yet.',
@@ -160,6 +161,7 @@ final class DiscoveryController
                 'question' => $question,
                 'answer' => '',
                 'citedItemIds' => [],
+                'citations' => [],
                 'noRelevantItems' => true,
                 'relatedItems' => $this->emptyResultSet(),
             ], $httpRequest, $account);
@@ -178,6 +180,11 @@ final class DiscoveryController
             'question' => $question,
             'answer' => $qaResponse->answer,
             'citedItemIds' => $qaResponse->citedItemIds,
+            'citations' => array_map(static fn ($c): array => [
+                'itemId' => $c->itemId,
+                'title' => $c->title,
+                'excerpt' => $c->excerpt,
+            ], $qaResponse->citations),
             'noRelevantItems' => $qaResponse->noRelevantItems,
             'relatedItems' => $this->serializeResultSet($related),
         ], $httpRequest, $account);

--- a/src/Http/Controller/ManagementController.php
+++ b/src/Http/Controller/ManagementController.php
@@ -6,7 +6,9 @@ namespace Giiken\Http\Controller;
 
 use Giiken\Entity\Community\Community;
 use Giiken\Entity\Community\CommunityRepositoryInterface;
+use Giiken\Export\ExportServiceInterface;
 use Giiken\Http\Inertia\InertiaHttpResponder;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Access\AccountInterface;
@@ -18,6 +20,7 @@ final class ManagementController
     public function __construct(
         private readonly ?CommunityRepositoryInterface $communityRepo = null,
         private readonly ?InertiaHttpResponder $inertiaHttp = null,
+        private readonly ?ExportServiceInterface $exportService = null,
     ) {}
 
     /**
@@ -135,6 +138,42 @@ final class ManagementController
             'community' => $community !== null ? $this->serializeCommunity($community) : null,
             'bootError' => null,
         ], $httpRequest, $account);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function exportDownload(
+        array $params,
+        array $query,
+        AccountInterface $account,
+        HttpRequest $httpRequest,
+    ): Response {
+        if ($this->communityRepo === null || $this->exportService === null) {
+            return new Response('Export service is not configured.', 503, [
+                'Content-Type' => 'text/plain; charset=UTF-8',
+            ]);
+        }
+
+        $inbound = InboundHttpRequest::fromSymfonyRequest($httpRequest, $params, $query);
+        $communitySlug = (string) $inbound->routeParam('communitySlug', '');
+        $community     = $this->communityRepo->findBySlug($communitySlug);
+        if ($community === null) {
+            return new Response('Community not found.', 404);
+        }
+
+        try {
+            $zipPath = $this->exportService->export($community, $account);
+        } catch (\RuntimeException $e) {
+            return new Response($e->getMessage(), 403);
+        }
+
+        $response = new BinaryFileResponse($zipPath);
+        $response->setContentDisposition('attachment', 'giiken-export-' . $community->getSlug() . '.zip');
+        $response->deleteFileAfterSend(true);
+
+        return $response;
     }
 
     /**

--- a/src/Http/Controller/QueryApiController.php
+++ b/src/Http/Controller/QueryApiController.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Http\Controller;
+
+use Giiken\Entity\Community\CommunityRepositoryInterface;
+use Giiken\Query\QaServiceInterface;
+use Giiken\Query\Report\ReportRequest;
+use Giiken\Query\Report\ReportServiceInterface;
+use Giiken\Query\SynthesisService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\AccountInterface;
+
+/**
+ * JSON endpoints for Phase 3 query layer (Q&A, reports, synthesis).
+ */
+final class QueryApiController
+{
+    public function __construct(
+        private readonly ?CommunityRepositoryInterface $communityRepo = null,
+        private readonly ?QaServiceInterface $qaService = null,
+        private readonly ?ReportServiceInterface $reportService = null,
+        private readonly ?SynthesisService $synthesisService = null,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function ask(
+        array $params,
+        array $query,
+        AccountInterface $account,
+        HttpRequest $httpRequest,
+    ): Response {
+        if ($this->communityRepo === null || $this->qaService === null) {
+            return new JsonResponse([
+                'error' => 'Q&A API is not configured.',
+            ], 503, ['Content-Type' => 'application/json']);
+        }
+
+        $body = $this->jsonBody($httpRequest);
+        if ($body === null) {
+            return new JsonResponse(['error' => 'Invalid JSON body.'], 400);
+        }
+
+        $communitySlug = (string) ($body['communitySlug'] ?? '');
+        $question      = trim((string) ($body['question'] ?? ''));
+        if ($communitySlug === '' || $question === '') {
+            return new JsonResponse(['error' => 'communitySlug and question are required.'], 422);
+        }
+
+        $community = $this->communityRepo->findBySlug($communitySlug);
+        if ($community === null) {
+            return new JsonResponse(['error' => 'Community not found.'], 404);
+        }
+
+        $communityId = (string) $community->get('id');
+        $qa          = $this->qaService->ask($question, $communityId, $account);
+
+        return new JsonResponse([
+            'answer'            => $qa->answer,
+            'citedItemIds'      => $qa->citedItemIds,
+            'citations'         => array_map(static fn ($c): array => [
+                'itemId'  => $c->itemId,
+                'title'   => $c->title,
+                'excerpt' => $c->excerpt,
+            ], $qa->citations),
+            'noRelevantItems'   => $qa->noRelevantItems,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function report(
+        array $params,
+        array $query,
+        AccountInterface $account,
+        HttpRequest $httpRequest,
+    ): Response {
+        if ($this->communityRepo === null || $this->reportService === null) {
+            return new JsonResponse(['error' => 'Report API is not configured.'], 503);
+        }
+
+        $body = $this->jsonBody($httpRequest);
+        if ($body === null) {
+            return new JsonResponse(['error' => 'Invalid JSON body.'], 400);
+        }
+
+        $communitySlug = (string) ($body['communitySlug'] ?? '');
+        if ($communitySlug === '') {
+            return new JsonResponse(['error' => 'communitySlug is required.'], 422);
+        }
+
+        $community = $this->communityRepo->findBySlug($communitySlug);
+        if ($community === null) {
+            return new JsonResponse(['error' => 'Community not found.'], 404);
+        }
+
+        $reportType = (string) ($body['reportType'] ?? '');
+        $from       = (string) ($body['dateFrom'] ?? $body['from'] ?? '');
+        $to         = (string) ($body['dateTo'] ?? $body['to'] ?? '');
+        if ($reportType === '' || $from === '' || $to === '') {
+            return new JsonResponse(['error' => 'reportType, dateFrom, and dateTo are required.'], 422);
+        }
+
+        /** @var string[] $kt */
+        $kt = [];
+        if (isset($body['knowledgeTypes']) && is_array($body['knowledgeTypes'])) {
+            $kt = array_values(array_map('strval', $body['knowledgeTypes']));
+        }
+
+        try {
+            $result = $this->reportService->generateFromRequest(
+                $community,
+                new ReportRequest(
+                    reportType: $reportType,
+                    dateFromIso: $from,
+                    dateToIso: $to,
+                    knowledgeTypeValues: $kt,
+                ),
+                $account,
+            );
+        } catch (\InvalidArgumentException $e) {
+            return new JsonResponse(['error' => $e->getMessage()], 422);
+        } catch (\RuntimeException $e) {
+            return new JsonResponse(['error' => $e->getMessage()], 403);
+        }
+
+        return new JsonResponse([
+            'markdown'          => $result->markdown,
+            'includedItemCount' => $result->includedItemCount,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function saveSynthesis(
+        array $params,
+        array $query,
+        AccountInterface $account,
+        HttpRequest $httpRequest,
+    ): Response {
+        if ($this->communityRepo === null || $this->synthesisService === null) {
+            return new JsonResponse(['error' => 'Synthesis API is not configured.'], 503);
+        }
+
+        if (!$account->isAuthenticated()) {
+            return new JsonResponse(['error' => 'Authentication required.'], 401);
+        }
+
+        $body = $this->jsonBody($httpRequest);
+        if ($body === null) {
+            return new JsonResponse(['error' => 'Invalid JSON body.'], 400);
+        }
+
+        $communitySlug = (string) ($body['communitySlug'] ?? '');
+        if ($communitySlug === '') {
+            return new JsonResponse(['error' => 'communitySlug is required.'], 422);
+        }
+
+        $community = $this->communityRepo->findBySlug($communitySlug);
+        if ($community === null) {
+            return new JsonResponse(['error' => 'Community not found.'], 404);
+        }
+
+        $title = (string) ($body['title'] ?? 'Q&A synthesis');
+        $text  = (string) ($body['content'] ?? $body['answer'] ?? '');
+        /** @var mixed $rawIds */
+        $rawIds = $body['citedItemIds'] ?? [];
+        if (!is_array($rawIds)) {
+            return new JsonResponse(['error' => 'citedItemIds must be an array of strings.'], 422);
+        }
+        $citedIds = array_values(array_map('strval', $rawIds));
+
+        try {
+            $saved = $this->synthesisService->saveFromQa(
+                (string) $community->get('id'),
+                $title,
+                $text,
+                $citedIds,
+                $account,
+            );
+        } catch (\InvalidArgumentException $e) {
+            return new JsonResponse(['error' => $e->getMessage()], 422);
+        } catch (\RuntimeException $e) {
+            return new JsonResponse(['error' => $e->getMessage()], 403);
+        }
+
+        return new JsonResponse(['item' => $saved], 201);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function jsonBody(HttpRequest $httpRequest): ?array
+    {
+        $raw = $httpRequest->getContent();
+        if ($raw === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/src/Pipeline/Provider/NullLlmProvider.php
+++ b/src/Pipeline/Provider/NullLlmProvider.php
@@ -11,7 +11,17 @@ final class NullLlmProvider implements LlmProviderInterface
 {
     public function complete(string $systemPrompt, string $userPrompt): string
     {
+        if (preg_match_all('/\[([a-zA-Z0-9_-]+)\]/', $userPrompt, $m) > 0) {
+            $ids = array_values(array_unique($m[1]));
+            if ($ids !== []) {
+                $first = $ids[0];
+
+                return 'Configure a real LLM provider for production Q&A. '
+                    . "Stub answer citing the knowledge base [{$first}].";
+            }
+        }
+
         return 'Configure a real LLM provider for production Q&A. '
-            . 'Stub response: see context lines above for [item-…] citations.';
+            . 'No bracketed item IDs were found in the stub context.';
     }
 }

--- a/src/Query/QaCitation.php
+++ b/src/Query/QaCitation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Query;
+
+final readonly class QaCitation
+{
+    public function __construct(
+        public string $itemId,
+        public string $title,
+        public string $excerpt,
+    ) {}
+}

--- a/src/Query/QaResponse.php
+++ b/src/Query/QaResponse.php
@@ -7,11 +7,13 @@ namespace Giiken\Query;
 final readonly class QaResponse
 {
     /**
-     * @param string[] $citedItemIds
+     * @param string[]       $citedItemIds
+     * @param QaCitation[] $citations
      */
     public function __construct(
         public string $answer,
         public array $citedItemIds,
         public bool $noRelevantItems,
+        public array $citations = [],
     ) {}
 }

--- a/src/Query/QaService.php
+++ b/src/Query/QaService.php
@@ -9,9 +9,10 @@ use Waaseyaa\Access\AccountInterface;
 
 final class QaService implements QaServiceInterface
 {
-    private const SYSTEM_PROMPT = 'You are a knowledge assistant for an Indigenous community. Answer the question using ONLY the provided context. Cite sources by their item ID in square brackets (e.g., [item-123]). If the context does not contain enough information to answer, say so. Never fabricate information.';
+    private const SYSTEM_PROMPT = 'You are a knowledge assistant for an Indigenous community. Answer the question using ONLY the provided context. Cite sources by repeating each source ID in square brackets exactly as shown at the start of every context block (e.g. [42] when the line begins with [42]). If the context does not contain enough information to answer, say so. Never fabricate information.';
     private const NO_INFO_MSG   = "I don't have enough information in this community's knowledge base to answer that question.";
-    private const CITATION_RE   = '/\[(item-[^\]]+)\]/';
+    /** IDs from context lines: alphanumeric, underscore, hyphen (matches numeric DB ids). */
+    private const CITATION_RE = '/\[([a-zA-Z0-9_-]+)\]/';
 
     public function __construct(
         private readonly SearchService $searchService,
@@ -34,7 +35,14 @@ final class QaService implements QaServiceInterface
                 answer: self::NO_INFO_MSG,
                 citedItemIds: [],
                 noRelevantItems: true,
+                citations: [],
             );
+        }
+
+        /** @var array<string, SearchResultItem> $byId */
+        $byId = [];
+        foreach ($results->items as $item) {
+            $byId[$item->id] = $item;
         }
 
         $contextLines = array_map(
@@ -48,22 +56,62 @@ final class QaService implements QaServiceInterface
 
         $answer = $this->llmProvider->complete(self::SYSTEM_PROMPT, $userPrompt);
 
-        $citedItemIds = $this->parseCitations($answer);
+        $citedItemIds = $this->parseCitations($answer, $byId);
+        $citations    = $this->buildCitations($citedItemIds, $byId);
 
         return new QaResponse(
             answer: $answer,
             citedItemIds: $citedItemIds,
             noRelevantItems: false,
+            citations: $citations,
         );
     }
 
     /**
+     * @param array<string, SearchResultItem> $allowedIds
+     *
      * @return string[]
      */
-    private function parseCitations(string $answer): array
+    private function parseCitations(string $answer, array $allowedIds): array
     {
         preg_match_all(self::CITATION_RE, $answer, $matches);
+        $raw = array_values(array_unique($matches[1]));
 
-        return array_values(array_unique($matches[1]));
+        return array_values(array_filter($raw, static fn (string $id): bool => isset($allowedIds[$id])));
+    }
+
+    /**
+     * @param string[]                        $citedItemIds
+     * @param array<string, SearchResultItem> $byId
+     *
+     * @return QaCitation[]
+     */
+    private function buildCitations(array $citedItemIds, array $byId): array
+    {
+        $out = [];
+        foreach ($citedItemIds as $id) {
+            $item = $byId[$id] ?? null;
+            if ($item === null) {
+                continue;
+            }
+            $out[] = new QaCitation(
+                itemId: $item->id,
+                title: $item->title,
+                excerpt: $this->excerpt($item->summary),
+            );
+        }
+
+        return $out;
+    }
+
+    private function excerpt(string $text, int $maxLen = 280): string
+    {
+        $text = trim(preg_replace('/\s+/', ' ', $text) ?? '');
+
+        if (mb_strlen($text, 'UTF-8') <= $maxLen) {
+            return $text;
+        }
+
+        return mb_substr($text, 0, $maxLen - 1, 'UTF-8') . '…';
     }
 }

--- a/src/Query/Report/ReportRequest.php
+++ b/src/Query/Report/ReportRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Query\Report;
+
+/**
+ * @param string[] $knowledgeTypeValues Empty = use each report type's default filter only.
+ */
+final readonly class ReportRequest
+{
+    /**
+     * @param string[] $knowledgeTypeValues
+     */
+    public function __construct(
+        public string $reportType,
+        public string $dateFromIso,
+        public string $dateToIso,
+        public array $knowledgeTypeValues = [],
+    ) {}
+}

--- a/src/Query/Report/ReportResult.php
+++ b/src/Query/Report/ReportResult.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Query\Report;
+
+final readonly class ReportResult
+{
+    public function __construct(
+        public string $markdown,
+        public int $includedItemCount,
+    ) {}
+}

--- a/src/Query/Report/ReportService.php
+++ b/src/Query/Report/ReportService.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Giiken\Query\Report;
 
 use Giiken\Access\CommunityRole;
+use Giiken\Access\KnowledgeItemAccessPolicy;
 use Giiken\Entity\Community\Community;
+use Giiken\Entity\KnowledgeItem\KnowledgeItem;
 use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
 use Giiken\Entity\KnowledgeItem\KnowledgeType;
 use Waaseyaa\Access\AccountInterface;
@@ -38,8 +40,11 @@ final class ReportService implements ReportServiceInterface
     ];
 
     /** @param ReportRendererInterface[] $renderers */
-    public function __construct(array $renderers, private readonly KnowledgeItemRepositoryInterface $repository)
-    {
+    public function __construct(
+        array $renderers,
+        private readonly KnowledgeItemRepositoryInterface $repository,
+        private readonly KnowledgeItemAccessPolicy $accessPolicy,
+    ) {
         foreach ($renderers as $renderer) {
             $this->renderers[$renderer->getType()] = $renderer;
         }
@@ -51,14 +56,32 @@ final class ReportService implements ReportServiceInterface
         DateRange $dateRange,
         AccountInterface $account,
     ): string {
-        // 1. Resolve renderer
+        $result = $this->generateFromRequest(
+            $community,
+            new ReportRequest(
+                reportType: $reportType,
+                dateFromIso: $dateRange->from->format('Y-m-d'),
+                dateToIso: $dateRange->to->format('Y-m-d'),
+            ),
+            $account,
+        );
+
+        return $result->markdown;
+    }
+
+    public function generateFromRequest(
+        Community $community,
+        ReportRequest $request,
+        AccountInterface $account,
+    ): ReportResult {
+        $reportType = $request->reportType;
+
         if (!isset($this->renderers[$reportType])) {
             throw new \InvalidArgumentException("Unknown report type: {$reportType}");
         }
 
         $renderer = $this->renderers[$reportType];
 
-        // 2. Check access
         $requiredRole = self::REQUIRED_ROLES[$reportType] ?? CommunityRole::Admin;
         $accountRole  = $this->resolveRole($account, (string) $community->get('id'));
 
@@ -68,40 +91,89 @@ final class ReportService implements ReportServiceInterface
             );
         }
 
-        // 3. Load items
+        try {
+            $from = new \DateTimeImmutable($request->dateFromIso);
+            $to   = new \DateTimeImmutable($request->dateToIso);
+        } catch (\Exception $e) {
+            throw new \InvalidArgumentException('Invalid date range: ' . $e->getMessage(), 0, $e);
+        }
+
+        $dateRange = new DateRange(from: $from, to: $to);
+
         $communityId = (string) $community->get('id');
         $allItems    = $this->repository->findByCommunity($communityId);
 
-        // 4. Filter by knowledge type
+        $allItems = array_values(array_filter(
+            $allItems,
+            fn (KnowledgeItem $item): bool => $this->accessPolicy->access($item, 'view', $account)->isAllowed(),
+        ));
+
         $typeFilter = self::TYPE_FILTERS[$reportType] ?? null;
-        if ($typeFilter !== null) {
+        if ($request->knowledgeTypeValues !== []) {
+            $allowedTypes = [];
+            foreach ($request->knowledgeTypeValues as $raw) {
+                $kt = KnowledgeType::tryFrom((string) $raw);
+                if ($kt !== null) {
+                    $allowedTypes[$kt->value] = $kt;
+                }
+            }
+            if ($allowedTypes === []) {
+                throw new \InvalidArgumentException('knowledgeTypes contained no valid knowledge type values.');
+            }
             $allItems = array_values(array_filter(
                 $allItems,
-                static fn ($item) => $item->getKnowledgeType() === $typeFilter,
+                static fn (KnowledgeItem $item): bool =>
+                    $item->getKnowledgeType() !== null
+                    && isset($allowedTypes[$item->getKnowledgeType()->value]),
+            ));
+        } elseif ($typeFilter !== null) {
+            $allItems = array_values(array_filter(
+                $allItems,
+                static fn (KnowledgeItem $item): bool => $item->getKnowledgeType() === $typeFilter,
             ));
         }
 
-        // 5. Filter by date range
         $filtered = array_values(array_filter(
             $allItems,
-            static function ($item) use ($dateRange): bool {
-                $createdAt = $item->getCreatedAt();
-                if ($createdAt === '') {
-                    return false;
-                }
-
-                try {
-                    $date = new \DateTimeImmutable($createdAt);
-                } catch (\Exception) {
-                    return false;
-                }
-
-                return $dateRange->contains($date);
-            },
+            fn (KnowledgeItem $item): bool => $this->itemTimestampInRange($item, $dateRange),
         ));
 
-        // 6. Render and return
-        return $renderer->render($community, $filtered, $dateRange);
+        $markdown = $renderer->render($community, $filtered, $dateRange);
+
+        return new ReportResult(markdown: $markdown, includedItemCount: count($filtered));
+    }
+
+    private function itemTimestampInRange(KnowledgeItem $item, DateRange $dateRange): bool
+    {
+        $ts = $this->itemReportTimestamp($item);
+        if ($ts === null) {
+            return false;
+        }
+
+        return $dateRange->contains($ts);
+    }
+
+    private function itemReportTimestamp(KnowledgeItem $item): ?\DateTimeImmutable
+    {
+        $compiled = $item->getCompiledAt();
+        if ($compiled !== '') {
+            try {
+                return new \DateTimeImmutable($compiled);
+            } catch (\Exception) {
+                // fall through to created_at
+            }
+        }
+
+        $createdAt = $item->getCreatedAt();
+        if ($createdAt === '') {
+            return null;
+        }
+
+        try {
+            return new \DateTimeImmutable($createdAt);
+        } catch (\Exception) {
+            return null;
+        }
     }
 
     private function resolveRole(AccountInterface $account, string $communityId): CommunityRole

--- a/src/Query/Report/ReportServiceInterface.php
+++ b/src/Query/Report/ReportServiceInterface.php
@@ -15,4 +15,10 @@ interface ReportServiceInterface
         DateRange $dateRange,
         AccountInterface $account,
     ): string;
+
+    public function generateFromRequest(
+        Community $community,
+        ReportRequest $request,
+        AccountInterface $account,
+    ): ReportResult;
 }

--- a/src/Query/SynthesisAccessCapper.php
+++ b/src/Query/SynthesisAccessCapper.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Query;
+
+use Giiken\Entity\KnowledgeItem\AccessTier;
+use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+
+/**
+ * Derives access metadata for a synthesis item from cited knowledge items.
+ * Tier is the strictest among citations; restricted rows intersect allow-lists.
+ */
+final class SynthesisAccessCapper
+{
+    /**
+     * @param KnowledgeItem[] $cited
+     *
+     * @return array{access_tier: string, allowed_roles: string[], allowed_users: string[]}
+     */
+    public static function cap(array $cited): array
+    {
+        if ($cited === []) {
+            return [
+                'access_tier'   => AccessTier::Members->value,
+                'allowed_roles' => [],
+                'allowed_users' => [],
+            ];
+        }
+
+        $tier = AccessTier::Public;
+        foreach ($cited as $item) {
+            $tier = self::stricter($tier, $item->getAccessTier());
+        }
+
+        $allowedRoles = [];
+        $allowedUsers = [];
+        $restricted   = array_values(array_filter(
+            $cited,
+            static fn (KnowledgeItem $i): bool => $i->getAccessTier() === AccessTier::Restricted,
+        ));
+
+        if ($tier === AccessTier::Restricted && $restricted !== []) {
+            $allowedRoles = self::intersectStringLists(array_map(
+                static fn (KnowledgeItem $i): array => $i->getAllowedRoles(),
+                $restricted,
+            ));
+            $allowedUsers = self::intersectStringLists(array_map(
+                static fn (KnowledgeItem $i): array => $i->getAllowedUsers(),
+                $restricted,
+            ));
+        }
+
+        return [
+            'access_tier'   => $tier->value,
+            'allowed_roles' => $allowedRoles,
+            'allowed_users' => $allowedUsers,
+        ];
+    }
+
+    private static function stricter(AccessTier $a, AccessTier $b): AccessTier
+    {
+        return self::strictness($a) >= self::strictness($b) ? $a : $b;
+    }
+
+    private static function strictness(AccessTier $t): int
+    {
+        return match ($t) {
+            AccessTier::Public     => 1,
+            AccessTier::Members    => 2,
+            AccessTier::Staff      => 3,
+            AccessTier::Restricted => 4,
+        };
+    }
+
+    /**
+     * @param list<array<int, string>> $lists
+     *
+     * @return string[]
+     */
+    private static function intersectStringLists(array $lists): array
+    {
+        if ($lists === []) {
+            return [];
+        }
+
+        $first = array_shift($lists);
+        if ($first === []) {
+            return [];
+        }
+
+        $set = array_flip($first);
+        foreach ($lists as $list) {
+            if ($list === []) {
+                return [];
+            }
+            $set = array_intersect_key($set, array_flip($list));
+        }
+
+        return array_keys($set);
+    }
+}

--- a/src/Query/SynthesisService.php
+++ b/src/Query/SynthesisService.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Query;
+
+use Giiken\Access\KnowledgeItemAccessPolicy;
+use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use InvalidArgumentException;
+use RuntimeException;
+use Waaseyaa\Access\AccountInterface;
+
+final class SynthesisService
+{
+    public function __construct(
+        private readonly KnowledgeItemRepositoryInterface $items,
+        private readonly KnowledgeItemAccessPolicy $accessPolicy,
+    ) {}
+
+    /**
+     * @param string[] $citedItemIds
+     *
+     * @return array{id: string, uuid: string, title: string}
+     */
+    public function saveFromQa(
+        string $communityId,
+        string $title,
+        string $content,
+        array $citedItemIds,
+        AccountInterface $account,
+    ): array {
+        $title   = trim($title);
+        $content = trim($content);
+        if ($title === '' || $content === '') {
+            throw new InvalidArgumentException('Title and content are required.');
+        }
+
+        $citedItemIds = array_values(array_unique(array_filter($citedItemIds, static fn (string $id): bool => $id !== '')));
+
+        /** @var KnowledgeItem[] $cited */
+        $cited = [];
+        foreach ($citedItemIds as $id) {
+            $item = $this->items->find($id);
+            if ($item === null || $item->getCommunityId() !== $communityId) {
+                throw new RuntimeException("Unknown or out-of-scope knowledge item: {$id}");
+            }
+            if (!$this->accessPolicy->access($item, 'view', $account)->isAllowed()) {
+                throw new RuntimeException("Not allowed to cite item: {$id}");
+            }
+            $cited[] = $item;
+        }
+
+        $cap = SynthesisAccessCapper::cap($cited);
+
+        $uuid = self::randomUuidV4();
+
+        $item = new KnowledgeItem([
+            'uuid'           => $uuid,
+            'title'          => $title,
+            'content'        => $content,
+            'knowledge_type' => KnowledgeType::Synthesis->value,
+            'community_id'   => $communityId,
+            'access_tier'    => $cap['access_tier'],
+            'allowed_roles'  => $cap['allowed_roles'] === [] ? null : json_encode($cap['allowed_roles'], JSON_THROW_ON_ERROR),
+            'allowed_users'  => $cap['allowed_users'] === [] ? null : json_encode($cap['allowed_users'], JSON_THROW_ON_ERROR),
+            'compiled_at'    => date('c'),
+        ]);
+        $item->enforceIsNew(true);
+
+        $this->items->save($item);
+
+        return [
+            'id'    => (string) $item->get('id'),
+            'uuid'  => $uuid,
+            'title' => $title,
+        ];
+    }
+
+    private static function randomUuidV4(): string
+    {
+        $bytes = random_bytes(16);
+        $bytes[6] = chr((ord($bytes[6]) & 0x0f) | 0x40);
+        $bytes[8] = chr((ord($bytes[8]) & 0x3f) | 0x80);
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($bytes), 4));
+    }
+}

--- a/tests/Unit/Http/Controller/DiscoveryControllerTest.php
+++ b/tests/Unit/Http/Controller/DiscoveryControllerTest.php
@@ -147,6 +147,7 @@ final class DiscoveryControllerTest extends TestCase
         $page = $this->decodePage($response);
         self::assertSame('Discovery/Ask', $page['component']);
         self::assertSame('The answer', $page['props']['answer'] ?? null);
+        self::assertSame([], $page['props']['citations'] ?? null);
     }
 
     #[Test]

--- a/tests/Unit/Query/QaServiceTest.php
+++ b/tests/Unit/Query/QaServiceTest.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Giiken\Tests\Unit\Query;
 
+use Giiken\Entity\KnowledgeItem\KnowledgeType;
 use Giiken\Pipeline\Provider\LlmProviderInterface;
-use Giiken\Query\QaResponse;
 use Giiken\Query\QaService;
-use Giiken\Query\SearchQuery;
 use Giiken\Query\SearchResultItem;
 use Giiken\Query\SearchResultSet;
 use Giiken\Query\SearchService;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -19,147 +17,89 @@ use PHPUnit\Framework\TestCase;
 use Waaseyaa\Access\AccountInterface;
 
 #[CoversClass(QaService::class)]
-#[CoversClass(QaResponse::class)]
 final class QaServiceTest extends TestCase
 {
-    private const COMMUNITY = 'comm-1';
-
-    private SearchService&MockObject $searchService;
-    private LlmProviderInterface&MockObject $llmProvider;
-    private QaService $service;
-    private AccountInterface&MockObject $account;
+    /** @var SearchService&MockObject */
+    private SearchService $search;
+    /** @var LlmProviderInterface&MockObject */
+    private LlmProviderInterface $llm;
+    private QaService $qa;
 
     protected function setUp(): void
     {
-        $this->searchService = $this->createMock(SearchService::class);
-        $this->llmProvider   = $this->createMock(LlmProviderInterface::class);
-        $this->account       = $this->createMock(AccountInterface::class);
-
-        $this->service = new QaService($this->searchService, $this->llmProvider);
+        $this->search = $this->createMock(SearchService::class);
+        $this->llm    = $this->createMock(LlmProviderInterface::class);
+        $this->qa     = new QaService($this->search, $this->llm);
     }
 
     #[Test]
-    public function successfulQaReturnsParsedCitations(): void
+    public function it_returns_structured_citations_for_ids_in_answer(): void
     {
-        $item1 = new SearchResultItem(
-            id: 'item-1',
-            title: 'Land Rights Overview',
-            summary: 'A summary of land rights.',
-            knowledgeType: KnowledgeType::Land,
-            score: 0.9,
-        );
-        $item2 = new SearchResultItem(
-            id: 'item-2',
-            title: 'Governance Principles',
-            summary: 'Community governance details.',
-            knowledgeType: KnowledgeType::Governance,
-            score: 0.8,
-        );
-
-        $resultSet = new SearchResultSet(
-            items: [$item1, $item2],
+        $items = [
+            new SearchResultItem('42', 'Treaty primer', 'Summary about treaties.', KnowledgeType::Governance, 0.9),
+            new SearchResultItem('7', 'Other', 'Unrelated.', KnowledgeType::Cultural, 0.5),
+        ];
+        $this->search->method('search')->willReturn(new SearchResultSet(
+            items: $items,
             totalHits: 2,
             totalPages: 1,
+        ));
+
+        $this->llm->method('complete')->willReturn(
+            'The treaty process is documented in source [42].',
         );
 
-        $this->searchService
-            ->expects($this->once())
-            ->method('search')
-            ->willReturn($resultSet);
+        $account = $this->createStub(AccountInterface::class);
+        $r       = $this->qa->ask('What about treaties?', 'comm-1', $account);
 
-        $llmAnswer = 'Based on the knowledge base, land rights are described in [item-1] and governance principles in [item-2].';
-
-        $this->llmProvider
-            ->expects($this->once())
-            ->method('complete')
-            ->willReturn($llmAnswer);
-
-        $response = $this->service->ask('What are land rights?', self::COMMUNITY, $this->account);
-
-        $this->assertInstanceOf(QaResponse::class, $response);
-        $this->assertFalse($response->noRelevantItems);
-        $this->assertSame($llmAnswer, $response->answer);
-        $this->assertEqualsCanonicalizing(['item-1', 'item-2'], $response->citedItemIds);
+        self::assertSame(['42'], $r->citedItemIds);
+        self::assertCount(1, $r->citations);
+        self::assertSame('42', $r->citations[0]->itemId);
+        self::assertSame('Treaty primer', $r->citations[0]->title);
+        self::assertStringContainsString('Summary about', $r->citations[0]->excerpt);
     }
 
     #[Test]
-    public function noResultsReturnsNoRelevantItemsWithoutCallingLlm(): void
+    public function it_strips_citations_not_in_search_results(): void
     {
-        $this->searchService
-            ->expects($this->once())
-            ->method('search')
-            ->willReturn(SearchResultSet::empty());
+        $items = [new SearchResultItem('1', 'Only', 'Body', KnowledgeType::Land, 1.0)];
+        $this->search->method('search')->willReturn(new SearchResultSet($items, 1, 1));
+        $this->llm->method('complete')->willReturn('See [999] and [1].');
 
-        $this->llmProvider
-            ->expects($this->never())
-            ->method('complete');
+        $account = $this->createStub(AccountInterface::class);
+        $r       = $this->qa->ask('Q', 'c', $account);
 
-        $response = $this->service->ask('What is the sky?', self::COMMUNITY, $this->account);
-
-        $this->assertTrue($response->noRelevantItems);
-        $this->assertSame(
-            "I don't have enough information in this community's knowledge base to answer that question.",
-            $response->answer,
-        );
-        $this->assertSame([], $response->citedItemIds);
+        self::assertSame(['1'], $r->citedItemIds);
     }
 
     #[Test]
-    public function citationParsingHandlesMultipleFormatsAndDeduplicates(): void
+    public function empty_search_yields_no_citations(): void
     {
-        $item = new SearchResultItem(
-            id: 'item-abc',
-            title: 'Cultural Practices',
-            summary: 'Cultural summary here.',
-            knowledgeType: KnowledgeType::Cultural,
-            score: 0.95,
-        );
+        $this->search->method('search')->willReturn(SearchResultSet::empty());
 
-        $resultSet = new SearchResultSet(
-            items: [$item],
-            totalHits: 1,
-            totalPages: 1,
-        );
+        $this->llm->expects(self::never())->method('complete');
 
-        $this->searchService
-            ->expects($this->once())
-            ->method('search')
-            ->willReturn($resultSet);
-
-        // Answer cites item-abc twice and item-def-456 once
-        $llmAnswer = 'See [item-abc] for cultural detail. Also [item-def-456] is relevant. [item-abc] confirms this.';
-
-        $this->llmProvider
-            ->expects($this->once())
-            ->method('complete')
-            ->willReturn($llmAnswer);
-
-        $response = $this->service->ask('Tell me about culture.', self::COMMUNITY, $this->account);
-
-        $this->assertFalse($response->noRelevantItems);
-        // item-abc should appear once (deduplicated), item-def-456 once
-        $this->assertCount(2, $response->citedItemIds);
-        $this->assertContains('item-abc', $response->citedItemIds);
-        $this->assertContains('item-def-456', $response->citedItemIds);
+        $r = $this->qa->ask('Q', 'c', null);
+        self::assertTrue($r->noRelevantItems);
+        self::assertSame([], $r->citations);
     }
 
     #[Test]
-    public function searchQueryIsBuiltCorrectly(): void
+    public function citation_excerpt_truncates_on_utf8_codepoints_not_bytes(): void
     {
-        $this->searchService
-            ->expects($this->once())
-            ->method('search')
-            ->with(
-                $this->callback(function (SearchQuery $query): bool {
-                    return $query->query === 'What is governance?'
-                        && $query->communityId === self::COMMUNITY
-                        && $query->page === 1
-                        && $query->pageSize === 5;
-                }),
-                $this->account,
-            )
-            ->willReturn(SearchResultSet::empty());
+        $longSummary = str_repeat('é', 400);
+        $items       = [
+            new SearchResultItem('1', 'T', $longSummary, KnowledgeType::Cultural, 1.0),
+        ];
+        $this->search->method('search')->willReturn(new SearchResultSet($items, 1, 1));
+        $this->llm->method('complete')->willReturn('Answer [1].');
 
-        $this->service->ask('What is governance?', self::COMMUNITY, $this->account);
+        $r = $this->qa->ask('Q', 'c', $this->createStub(AccountInterface::class));
+
+        self::assertCount(1, $r->citations);
+        $excerpt = $r->citations[0]->excerpt;
+        self::assertTrue(mb_check_encoding($excerpt, 'UTF-8'));
+        self::assertLessThanOrEqual(280, mb_strlen($excerpt, 'UTF-8'));
+        self::assertStringEndsWith('…', $excerpt);
     }
 }

--- a/tests/Unit/Query/Report/ReportServiceTest.php
+++ b/tests/Unit/Query/Report/ReportServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Giiken\Tests\Unit\Query\Report;
 
 use Giiken\Entity\Community\Community;
+use Giiken\Access\KnowledgeItemAccessPolicy;
 use Giiken\Entity\KnowledgeItem\KnowledgeItem;
 use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
 use Giiken\Entity\KnowledgeItem\KnowledgeType;
@@ -48,6 +49,7 @@ final class ReportServiceTest extends TestCase
                 new LandBriefReport(),
             ],
             $this->repository,
+            new KnowledgeItemAccessPolicy(),
         );
     }
 
@@ -110,7 +112,7 @@ final class ReportServiceTest extends TestCase
     }
 
     #[Test]
-    public function filters_by_date_range(): void
+    public function filters_by_date_range_using_created_at_when_compiled_at_empty(): void
     {
         $inRange  = $this->item(KnowledgeType::Governance, '2025-06-15');
         $outRange = $this->item(KnowledgeType::Governance, '2024-12-31');
@@ -118,6 +120,23 @@ final class ReportServiceTest extends TestCase
         $this->repository
             ->method('findByCommunity')
             ->willReturn([$inRange, $outRange]);
+
+        $account = $this->account(['giiken.community.' . self::COMMUNITY_ID . '.staff']);
+
+        $output = $this->service->generate('governance_summary', $this->community, $this->dateRange, $account);
+
+        $this->assertStringContainsString('1 governance item(s)', $output);
+    }
+
+    #[Test]
+    public function filters_by_compiled_at_when_set(): void
+    {
+        $inRange = $this->item(KnowledgeType::Governance, '2020-01-01', '2025-06-15');
+        $ignoredCreated = $this->item(KnowledgeType::Governance, '2025-08-01', '2024-06-01');
+
+        $this->repository
+            ->method('findByCommunity')
+            ->willReturn([$inRange, $ignoredCreated]);
 
         $account = $this->account(['giiken.community.' . self::COMMUNITY_ID . '.staff']);
 
@@ -140,15 +159,20 @@ final class ReportServiceTest extends TestCase
     // Helpers
     // ------------------------------------------------------------------
 
-    private function item(KnowledgeType $type, string $createdAt): KnowledgeItem
+    private function item(KnowledgeType $type, string $createdAt, string $compiledAt = ''): KnowledgeItem
     {
-        return new KnowledgeItem([
+        $values = [
             'title'          => 'Item ' . $type->value,
             'content'        => 'Body for ' . $type->value,
             'knowledge_type' => $type->value,
             'community_id'   => self::COMMUNITY_ID,
             'created_at'     => $createdAt,
-        ]);
+        ];
+        if ($compiledAt !== '') {
+            $values['compiled_at'] = $compiledAt;
+        }
+
+        return new KnowledgeItem($values);
     }
 
     /**

--- a/tests/Unit/Query/SynthesisAccessCapperTest.php
+++ b/tests/Unit/Query/SynthesisAccessCapperTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Tests\Unit\Query;
+
+use Giiken\Entity\KnowledgeItem\AccessTier;
+use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use Giiken\Query\SynthesisAccessCapper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SynthesisAccessCapper::class)]
+final class SynthesisAccessCapperTest extends TestCase
+{
+    #[Test]
+    public function empty_citations_default_to_members_tier(): void
+    {
+        $cap = SynthesisAccessCapper::cap([]);
+        self::assertSame('members', $cap['access_tier']);
+        self::assertSame([], $cap['allowed_roles']);
+        self::assertSame([], $cap['allowed_users']);
+    }
+
+    #[Test]
+    public function picks_strictest_non_restricted_tier(): void
+    {
+        $items = [
+            $this->item(AccessTier::Public, [], []),
+            $this->item(AccessTier::Staff, [], []),
+        ];
+        $cap = SynthesisAccessCapper::cap($items);
+        self::assertSame('staff', $cap['access_tier']);
+        self::assertSame([], $cap['allowed_roles']);
+    }
+
+    #[Test]
+    public function restricted_intersects_allowed_roles(): void
+    {
+        $items = [
+            $this->item(AccessTier::Restricted, ['a', 'b'], []),
+            $this->item(AccessTier::Restricted, ['b', 'c'], []),
+        ];
+        $cap = SynthesisAccessCapper::cap($items);
+        self::assertSame('restricted', $cap['access_tier']);
+        self::assertSame(['b'], $cap['allowed_roles']);
+    }
+
+    /**
+     * @param string[] $roles
+     * @param string[] $users
+     */
+    private function item(AccessTier $tier, array $roles, array $users): KnowledgeItem
+    {
+        return new KnowledgeItem([
+            'title'          => 'x',
+            'content'        => 'y',
+            'community_id'   => 'c1',
+            'knowledge_type' => KnowledgeType::Governance->value,
+            'access_tier'    => $tier->value,
+            'allowed_roles'  => $roles === [] ? null : json_encode($roles, JSON_THROW_ON_ERROR),
+            'allowed_users'  => $users === [] ? null : json_encode($users, JSON_THROW_ON_ERROR),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the backend slice of **Phase 3: Query Layer**: JSON APIs, report generation improvements, export download wiring, and synthesis save path with access capping. Q&A citation excerpts use **UTF-8-safe** truncation (`mb_strlen` / `mb_substr`).

## What changed

- **Q&A (#11):** `QaCitation`, structured citations on Inertia + `POST /api/v1/ask`; prompts and citation parsing aligned with real search item IDs; `NullLlmProvider` stub cites IDs from context.
- **Reports (#12):** `ReportRequest` / `ReportResult`, `generateFromRequest()`, optional `knowledgeTypes`, `compiled_at` (fallback `created_at`), items filtered by `KnowledgeItemAccessPolicy`; `POST /api/v1/report`.
- **Export (#13):** `ExportServiceInterface` registered; `GET /{communitySlug}/manage/export/download` (admin enforced in `ExportService`). Placeholder `embeddings.json` / `users.yaml` unchanged.
- **Synthesis (#24):** `KnowledgeType::Synthesis`, `SynthesisAccessCapper`, `SynthesisService`, `POST /api/v1/synthesis`.
- **Docs:** `docs/architecture/lifecycle.md` updated for new routes and DI.

## Verification

- `./vendor/bin/phpunit` (179 tests)
- `composer analyse` (PHPStan)

## Issues

Closes #11, closes #12, closes #24. Closes #13 for the current export scope (ZIP + knowledge markdown + community YAML); follow-ups remain for richer embeddings/users export if desired.


Made with [Cursor](https://cursor.com)