### PR TITLE
feat(#14): Inertia Discover landing and Giiken Vite wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install npm dependencies and build frontend
+        run: npm ci && npm run build
+
       - name: Check lifecycle documentation drift
         run: ./scripts/check-lifecycle-drift.sh
 

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -45,6 +45,8 @@ The first Giiken app-level class in normal boot is `Giiken\GiikenServiceProvider
 
 - `register()` contributes app entity types (`community`, `knowledge_item`, `wiki_lint_report`)
 - `register()` binds app services resolved by SSR `serviceResolver`: `CommunityRepositoryInterface`, `KnowledgeItemRepositoryInterface`, `SearchService`, `QaServiceInterface`, `ReportServiceInterface`, `ExportServiceInterface`, `SynthesisService`, dev `NullEmbeddingProvider` / `NullLlmProvider`, and a PSR-14 `EventDispatcherInterface` alias to the kernel dispatcher (for `EntityRepository` construction); registers `Giiken\Http\Inertia\InertiaHttpResponder` (full-page renderer from DI when present)
+- `register()` re-binds `InertiaFullPageRendererInterface` with a project-root-based `ViteAssetManager` (`public/build` manifest or `VITE_DEV_SERVER`), sets `Inertia::setVersion('giiken')`, and refreshes `Inertia::setRenderer(...)` so asset paths do not depend on `getcwd()`
+- Frontend bundle: Vite entry `resources/js/app.ts`, production output under `public/build` (`npm run build`); set `VITE_DEV_SERVER` (e.g. `http://127.0.0.1:5173`) when using `npm run dev` for HMR
 - `commands()` contributes CLI commands (`giiken:seed:test-community`)
 - `routes()` contributes app HTTP routes (discovery, management, `GET`/`POST` `/login`, `GET` `/logout`)
 
@@ -77,6 +79,7 @@ After boot, `HttpKernel::serveHttpRequest()` executes:
 
 App routes are added through `GiikenServiceProvider::routes(...)`, including:
 
+- Public landing (Inertia): `GET` `/` → `Discover` page (`HomeController::discover`)
 - Session HTML auth (public): `GET`/`POST` `/login`, `GET` `/logout`
 - Discovery:
   - `/{communitySlug}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "giiken",
       "dependencies": {
         "@inertiajs/vue3": "^2.0",
         "vue": "^3.5"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "giiken",
   "private": true,
   "type": "module",
   "scripts": {

--- a/resources/js/Pages/Discover.vue
+++ b/resources/js/Pages/Discover.vue
@@ -1,0 +1,6 @@
+<template>
+  <h1>Discover</h1>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,16 +1,19 @@
-import { createApp, h } from 'vue'
-import { createInertiaApp } from '@inertiajs/vue3'
-import '../css/app.css'
+import { createInertiaApp } from '@inertiajs/vue3';
+import type { DefineComponent } from 'vue';
+import { createApp, h } from 'vue';
+import '../css/app.css';
 
 createInertiaApp({
-  progress: { color: '#3d35c8' },
-  resolve: (name: string) => {
-    const pages = import.meta.glob('./Pages/**/*.vue', { eager: true })
-    return pages[`./Pages/${name}.vue`]
-  },
-  setup({ el, App, props, plugin }) {
-    createApp({ render: () => h(App, props) })
-      .use(plugin)
-      .mount(el)
-  },
-})
+    progress: { color: '#3d35c8' },
+    resolve: (name: string) => {
+        const pages = import.meta.glob<{ default: DefineComponent }>('./Pages/**/*.vue', { eager: true });
+        const page = pages[`./Pages/${name}.vue`];
+
+        return page?.default;
+    },
+    setup({ el, App, props, plugin }) {
+        createApp({ render: () => h(App, props) })
+            .use(plugin)
+            .mount(el);
+    },
+});

--- a/resources/js/env.d.ts
+++ b/resources/js/env.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+    import type { DefineComponent } from 'vue';
+
+    const component: DefineComponent<object, object, unknown>;
+    export default component;
+}

--- a/src/GiikenServiceProvider.php
+++ b/src/GiikenServiceProvider.php
@@ -15,6 +15,7 @@ use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
 use Giiken\Export\ExportService;
 use Giiken\Export\ExportServiceInterface;
 use Giiken\Http\Controller\DiscoveryController;
+use Giiken\Http\Controller\HomeController;
 use Giiken\Http\Controller\ManagementController;
 use Giiken\Http\Controller\QueryApiController;
 use Giiken\Http\Controller\WebLoginController;
@@ -39,11 +40,14 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDi
 use Waaseyaa\Database\DatabaseInterface;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Foundation\Asset\ViteAssetManager;
+use Waaseyaa\Foundation\Http\Inertia\InertiaFullPageRendererInterface;
 use Waaseyaa\EntityStorage\Connection\SingleConnectionResolver;
 use Waaseyaa\EntityStorage\Driver\SqlStorageDriver;
 use Waaseyaa\EntityStorage\EntityRepository as WaaseyaaEntityRepository;
-use Waaseyaa\Foundation\Http\Inertia\InertiaFullPageRendererInterface;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
+use Waaseyaa\Inertia\Inertia;
+use Waaseyaa\Inertia\RootTemplateRenderer;
 use Waaseyaa\Routing\RouteBuilder;
 use Waaseyaa\Routing\WaaseyaaRouter;
 use Waaseyaa\Search\SearchIndexerInterface;
@@ -187,6 +191,28 @@ final class GiikenServiceProvider extends ServiceProvider
                 $this->resolve(KnowledgeItemAccessPolicy::class),
             );
         });
+
+        $this->registerInertiaViteRenderer();
+    }
+
+    /**
+     * Use project-root-based Vite paths (not getcwd()) so assets resolve under PHPUnit and CLI.
+     */
+    private function registerInertiaViteRenderer(): void
+    {
+        $projectRoot = dirname(__DIR__);
+        $rawDev = $_ENV['VITE_DEV_SERVER'] ?? getenv('VITE_DEV_SERVER');
+        $devServerUrl = is_string($rawDev) && $rawDev !== '' ? $rawDev : null;
+
+        $assetManager = new ViteAssetManager(
+            basePath: $projectRoot . '/public',
+            baseUrl: '',
+            devServerUrl: $devServerUrl,
+        );
+        $renderer = new RootTemplateRenderer(assetManager: $assetManager);
+        Inertia::setRenderer($renderer);
+        Inertia::setVersion('giiken');
+        $this->singleton(InertiaFullPageRendererInterface::class, static fn (): InertiaFullPageRendererInterface => $renderer);
     }
 
     public function commands(
@@ -205,6 +231,16 @@ final class GiikenServiceProvider extends ServiceProvider
 
     public function routes(WaaseyaaRouter $router, ?EntityTypeManager $entityTypeManager = null): void
     {
+        $router->addRoute(
+            'giiken.home',
+            RouteBuilder::create('/')
+                ->controller(HomeController::class . '::discover')
+                ->methods('GET')
+                ->allowAll()
+                ->render()
+                ->build(),
+        );
+
         $router->addRoute(
             'giiken.login',
             RouteBuilder::create('/login')

--- a/src/Http/Controller/HomeController.php
+++ b/src/Http/Controller/HomeController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Http\Controller;
+
+use Giiken\Http\Inertia\InertiaHttpResponder;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Inertia\Inertia;
+
+/**
+ * Public landing route: Inertia {@see Discover} page (Phase 4 UX skeleton).
+ */
+final class HomeController
+{
+    public function __construct(
+        private readonly ?InertiaHttpResponder $inertiaHttp = null,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function discover(
+        array $params,
+        array $query,
+        AccountInterface $account,
+        HttpRequest $httpRequest,
+    ): Response {
+        if ($this->inertiaHttp === null) {
+            return new Response('Giiken: InertiaHttpResponder is not registered.', 500, [
+                'Content-Type' => 'text/plain; charset=UTF-8',
+            ]);
+        }
+
+        return $this->inertiaHttp->toResponse(
+            Inertia::render('Discover', []),
+            $httpRequest,
+            $account,
+        );
+    }
+}

--- a/tests/Integration/Http/DiscoverPageTest.php
+++ b/tests/Integration/Http/DiscoverPageTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giiken\Tests\Integration\Http;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Foundation\Kernel\AbstractKernel;
+use Waaseyaa\Foundation\Kernel\HttpKernel;
+
+#[CoversNothing]
+final class DiscoverPageTest extends TestCase
+{
+    private static string $projectRoot;
+    private static HttpKernel $kernel;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$projectRoot = dirname(__DIR__, 3);
+        $cachePath = self::$projectRoot . '/storage/framework/packages.php';
+        if (is_file($cachePath)) {
+            unlink($cachePath);
+        }
+
+        putenv('WAASEYAA_DB=:memory:');
+
+        self::$kernel = new HttpKernel(self::$projectRoot);
+        $boot = new \ReflectionMethod(AbstractKernel::class, 'boot');
+        $boot->invoke(self::$kernel);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        putenv('WAASEYAA_DB');
+        $cachePath = self::$projectRoot . '/storage/framework/packages.php';
+        if (is_file($cachePath)) {
+            unlink($cachePath);
+        }
+    }
+
+    #[Test]
+    public function get_root_returns_inertia_discover_page(): void
+    {
+        $response = $this->handleKernelRequest('GET', '/', []);
+
+        self::assertSame(200, $response->getStatusCode());
+        $content = (string) $response->getContent();
+        self::assertStringContainsString('text/html', (string) $response->headers->get('Content-Type'));
+        self::assertStringContainsString('"component":"Discover"', $content);
+        self::assertMatchesRegularExpression(
+            '/<script[^>]+data-page="true"[^>]*>/',
+            $content,
+        );
+    }
+
+    #[Test]
+    public function get_root_x_inertia_returns_json_page_object(): void
+    {
+        $response = $this->handleKernelRequest('GET', '/', [
+            'HTTP_X_INERTIA' => 'true',
+            'HTTP_X_INERTIA_VERSION' => 'giiken',
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('true', $response->headers->get('X-Inertia'));
+        $decoded = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+        self::assertSame('Discover', $decoded['component'] ?? null);
+    }
+
+    /**
+     * @param array<string, string> $extraServer
+     */
+    private function handleKernelRequest(string $method, string $uri, array $extraServer): Response
+    {
+        $saved = $_SERVER;
+        $_SERVER = array_merge($saved, [
+            'REQUEST_METHOD' => $method,
+            'REQUEST_URI' => $uri,
+            'HTTP_HOST' => 'localhost',
+            'SCRIPT_NAME' => '/index.php',
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT' => '80',
+        ], $extraServer);
+
+        try {
+            return self::$kernel->handle();
+        } finally {
+            $_SERVER = $saved;
+        }
+    }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,18 +1,23 @@
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
-import tailwindcss from '@tailwindcss/vite'
-import { fileURLToPath, URL } from 'node:url'
+import tailwindcss from '@tailwindcss/vite';
+import vue from '@vitejs/plugin-vue';
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [vue(), tailwindcss()],
-  resolve: {
-    alias: { '@': fileURLToPath(new URL('./resources/js', import.meta.url)) },
-  },
-  build: {
-    manifest: true,
-    outDir: 'public/build',
-    rollupOptions: {
-      input: 'resources/js/app.ts',
+    plugins: [vue(), tailwindcss()],
+    resolve: {
+        alias: { '@': fileURLToPath(new URL('./resources/js', import.meta.url)) },
     },
-  },
-})
+    build: {
+        manifest: true,
+        outDir: 'public/build',
+        emptyOutDir: true,
+        rollupOptions: {
+            input: 'resources/js/app.ts',
+        },
+    },
+    server: {
+        port: 5173,
+        strictPort: true,
+    },
+});


### PR DESCRIPTION
## Summary
Implements Phase 4 issue **#14**: public `GET /` serves the Inertia **Discover** page, with reliable Vite asset resolution from the project root (not `getcwd()`), integration tests, and CI building the frontend before PHPUnit.

## Changes
- **Route:** `giiken.home` → `HomeController::discover` → `Inertia::render('Discover', [])`
- **Provider:** `registerInertiaViteRenderer()` rebinds `InertiaFullPageRendererInterface`, `Inertia::setVersion('giiken')`, `Inertia::setRenderer`
- **Frontend:** `resources/js/Pages/Discover.vue`, `env.d.ts`, `app.ts` typed for `vue-tsc`; Vite `emptyOutDir` + dev server port
- **Tests:** `tests/Integration/Http/DiscoverPageTest.php` (full page + X-Inertia JSON)
- **CI:** Node 22, `npm ci && npm run build` before lifecycle check and PHPUnit
- **Docs:** `docs/architecture/lifecycle.md` updated for drift guard

## Verification
- `./vendor/bin/phpunit`
- `./vendor/bin/phpstan analyse src tests --level=8`
- `npm run build`

Closes #14

Made with [Cursor](https://cursor.com)