### PR TITLE
Boot-to-browser: composer overlay, CLI symlink, Discover landing (#53, #54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 /public/build/
 /storage/
 /waaseyaa-sync-*/
+
+# Local Composer overlay: symlink waaseyaa monorepo packages (see composer.local.json.example)
+/composer.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,36 +8,35 @@ Giiken is a sovereign indigenous knowledge management platform built on the **Wa
 
 **PHP:** 8.4+ | **License:** GPL-2.0-or-later | **Namespace:** `Giiken\` (PSR-4)
 
-## Boot-to-browser status (as of 2026-04-06, second probe)
+## Boot-to-browser status (as of 2026-04-11)
 
-`vendor/bin/waaseyaa serve` starts, but a `GET /{community-slug}` request cannot yet reach the controller. Each step was discovered by running the next and letting the next failure name the next gap. Do not skip levels.
+✅ **Phase A green.** Boot, migrations, seed, and SSR dispatch all work end-to-end on `waaseyaa/* ^0.1.0-alpha.120`.
 
-### Framework prerequisites (waaseyaa repo)
+Verified smoke path:
 
-1. ✅ **alpha.107** released — bundles cli bin entrypoint, `app.url` default, `[Class, method]` array-controller normalization (waaseyaa/framework#1125).
-2. ✅ **foundation→ssr dependency** — waaseyaa/framework#1127, **closed**. `composer update waaseyaa/*` was removing `vendor/waaseyaa/ssr` because foundation never declared it. Resolved upstream.
-3. 🟡 **EntityRepository factory** — waaseyaa/framework#1128. The framework provides no `EntityTypeManager::getRepository(string $id)` accessor. Building a working `Waaseyaa\EntityStorage\EntityRepository` requires manually assembling 3-7 dependencies. This is the architectural blocker for #42 below.
-4. 🟡 **Hook discipline** — waaseyaa/framework#1126 (spec-drift + phpunit pre-push hooks) is the meta-blocker for cutting alpha.108.
+```
+./bin/waaseyaa migrate                            # 1 migration applied
+./bin/waaseyaa giiken:seed:test-community         # community + 3 knowledge items
+./bin/waaseyaa serve                              # or php -S 127.0.0.1:8080 -t public public/index.php
+curl http://127.0.0.1:8080/                       # 200, Inertia "Discover"
+curl http://127.0.0.1:8080/test-community         # 200, Inertia "Discovery/Index" with seeded items
+```
 
-### Upgrade note (2026-04-10)
+PHPUnit: 198/198 passing.
 
-- Giiken requires **`waaseyaa/*` ^0.1.0-alpha.120** (see `docs/architecture/lifecycle.md` for `HydratableFromStorageInterface`, `$casts`, and `::make()` patterns on `Community`, `KnowledgeItem`, and `WikiLintReport`).
-- `waaseyaa/ssr` had to be re-added as an explicit app dependency to satisfy `Waaseyaa\User\UserServiceProvider` runtime wiring after `composer update "waaseyaa/*"`.
-- `public/index.php` now emits responses (`$response = $kernel->handle(); $response->send();`) to avoid zero-byte `200` responses.
-- Unit and full PHPUnit suites pass after updating controller/test signatures for the current SSR app-controller calling convention (`($params, $query, $account, $httpRequest)`).
-- Current runtime blocker: `GET /{community-slug}` still returns `500` (`<h1>Internal Server Error</h1>`) under `php -S`, despite dependency and signature fixes. This requires follow-up debugging in SSR dispatch/runtime error reporting.
+### Resolved (closed)
 
-### Giiken-side prerequisites (this repo)
+- waaseyaa/framework#1125 — cli bin entrypoint, `app.url` default, array-controller normalization (alpha.107).
+- waaseyaa/framework#1127 — foundation→ssr dependency.
+- giiken#42 — `GiikenServiceProvider` provider registrations.
+- giiken#43 — entity schema migrations (`community`, `knowledge_item`, `wiki_lint_report`).
+- giiken#44 — `giiken:seed:test-community` console command.
 
-5. 🔴 **Service registrations** — #42, blocked on framework#1128. `GiikenServiceProvider::register()` does not bind `SearchService`, `QaServiceInterface`, `CommunityRepositoryInterface`, or `KnowledgeItemRepositoryInterface`. `SsrPageHandler::resolveControllerInstance()` throws when reflecting `DiscoveryController`'s constructor. Wiring requires `EntityRepository` factory machinery that doesn't exist yet.
-6. 🔴 **Entity schema migration** — #43. No migration materializes `community`, `knowledge_item`, `wiki_lint_report` tables. `vendor/bin/waaseyaa migrate` reports "Nothing to migrate".
-7. 🔴 **Seed command** — #44. `vendor/bin/waaseyaa giiken:seed:test-community` does not exist.
-8. 🔴 **Real LLM providers** — #40. Comments in `GiikenServiceProvider` say `NullLlmAdapter`/`FakeEmbeddingAdapter` should wire `Waaseyaa\AI\Agent\Provider\NullLlmProvider`, but **that framework class does not exist** (`find packages/ai-agent -name 'NullLlm*'` is empty). #40 needs either a giiken-local null impl or a small framework precursor before it can land.
-9. 🔴 **Session auth** — #41. `HttpKernel` already has the `_account` pipeline machinery and `waaseyaa/auth` ships `LoginController`/`LogoutController`/`AuthenticateMiddleware`. The real gap is no login page, no test users seeded with community roles, no integration tests covering anonymous/member/staff tiers. The framing of "kernel passes null" in the original issue is partially outdated.
+### `vendor/bin/waaseyaa` is symlinked to the giiken wrapper
 
-### Two giiken-local interfaces have no concrete implementations
+`./bin/waaseyaa` is the giiken-local entry that loads `.env` and uses the project root. By default, composer installs `vendor/bin/waaseyaa` as a proxy to the `waaseyaa/cli` package's bin, which does **not** load `.env` and resolves `projectRoot` relative to its own vendor location — that path lands in `vendor/waaseyaa/cli/storage/waaseyaa.sqlite` and falls through to `APP_ENV=production`, tripping the `DatabaseBootstrapper` "must already exist" guard.
 
-`Giiken\Pipeline\Provider\LlmProviderInterface` and `Giiken\Pipeline\Provider\EmbeddingProviderInterface` exist with no production implementations — only anonymous classes inside test fixtures (`tests/Unit/Pipeline/Step/*Test.php`). #40 should also create concrete null implementations as a starting point.
+To make both invocations equivalent, `composer.json` runs a `post-install-cmd` / `post-update-cmd` that replaces `vendor/bin/waaseyaa` with a symlink to `../../bin/waaseyaa`. After any `composer install` / `composer update`, both `./bin/waaseyaa` and `./vendor/bin/waaseyaa` point at the same wrapper. This is a workaround for waaseyaa/framework#1226 — once that lands, the symlink hook can be removed.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # abaapi
 Sovereign knowledge management platform for Indigenous communities — built on Waaseyaa
+
+## Local Waaseyaa monorepo (path installs)
+
+Use this when you want Giiken to load `waaseyaa/*` from a checkout of [waaseyaa/framework](https://github.com/waaseyaa/framework) instead of waiting for Packagist tags.
+
+1. Place the repos side by side (paths in `composer.local.json.example` assume `../waaseyaa` next to this project root).
+2. `cp composer.local.json.example composer.local.json` (`composer.local.json` is gitignored).
+3. Run `composer update "waaseyaa/*"` so Composer symlinks `vendor/waaseyaa/*` to `../waaseyaa/packages/*`. You need `prepend-repositories` (already set in `composer.json` via the merge plugin) so the path repository wins over Packagist.
+4. **Lock file:** CI installs from the committed `composer.lock` (Packagist). After a path `composer update`, your `composer.lock` will reference `dist.type: path` — do not commit that unless the whole team uses path installs. To return to tagged packages: remove `composer.local.json`, `git checkout composer.lock`, then `composer install`.

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,13 @@
     "scripts": {
         "analyse": "./vendor/bin/phpstan analyse src tests --level=8 --no-progress",
         "dev": "php bin/waaseyaa serve",
-        "test": "./vendor/bin/phpunit"
+        "test": "./vendor/bin/phpunit",
+        "post-install-cmd": [
+            "@php -r \"if (file_exists('bin/waaseyaa') && is_dir('vendor/bin')) { @unlink('vendor/bin/waaseyaa'); symlink('../../bin/waaseyaa', 'vendor/bin/waaseyaa'); echo \\\"Repointed vendor/bin/waaseyaa -> bin/waaseyaa\\n\\\"; }\""
+        ],
+        "post-update-cmd": [
+            "@php -r \"if (file_exists('bin/waaseyaa') && is_dir('vendor/bin')) { @unlink('vendor/bin/waaseyaa'); symlink('../../bin/waaseyaa', 'vendor/bin/waaseyaa'); echo \\\"Repointed vendor/bin/waaseyaa -> bin/waaseyaa\\n\\\"; }\""
+        ]
     },
     "extra": {
         "merge-plugin": {

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,9 @@
         }
     },
     "config": {
+        "allow-plugins": {
+            "wikimedia/composer-merge-plugin": true
+        },
         "optimize-autoloader": true,
         "process-timeout": 0,
         "sort-packages": true
@@ -63,6 +66,12 @@
         "test": "./vendor/bin/phpunit"
     },
     "extra": {
+        "merge-plugin": {
+            "include": [
+                "composer.local.json"
+            ],
+            "prepend-repositories": true
+        },
         "waaseyaa": {
             "providers": [
                 "Giiken\\GiikenServiceProvider"
@@ -72,7 +81,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
+        "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.5",
-        "phpstan/phpstan": "^1.10"
+        "wikimedia/composer-merge-plugin": "^2.1"
     }
 }

--- a/composer.local.json.example
+++ b/composer.local.json.example
@@ -1,0 +1,11 @@
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../waaseyaa/packages/*",
+            "options": {
+                "symlink": true
+            }
+        }
+    ]
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce5e048a4ec1551f437ff61ad7a577c9",
+    "content-hash": "16676676baa9c2086fb9cc2202c5b51a",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -6608,6 +6608,62 @@
                 }
             ],
             "time": "2026-02-28T20:30:03+00:00"
+        },
+        {
+            "name": "wikimedia/composer-merge-plugin",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/composer-merge-plugin.git",
+                "reference": "a03d426c8e9fb2c9c569d9deeb31a083292788bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/composer-merge-plugin/zipball/a03d426c8e9fb2c9c569d9deeb31a083292788bc",
+                "reference": "a03d426c8e9fb2c9c569d9deeb31a083292788bc",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1||^2.0",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.1||^2.0",
+                "ext-json": "*",
+                "mediawiki/mediawiki-phan-config": "0.11.1",
+                "php-parallel-lint/php-parallel-lint": "~1.3.1",
+                "phpspec/prophecy": "~1.15.0",
+                "phpunit/phpunit": "^8.5||^9.0",
+                "squizlabs/php_codesniffer": "~3.7.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Wikimedia\\Composer\\Merge\\V2\\MergePlugin",
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Wikimedia\\Composer\\Merge\\V2\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Davis",
+                    "email": "bd808@wikimedia.org"
+                }
+            ],
+            "description": "Composer plugin to merge multiple composer.json files",
+            "support": {
+                "issues": "https://github.com/wikimedia/composer-merge-plugin/issues",
+                "source": "https://github.com/wikimedia/composer-merge-plugin/tree/v2.1.0"
+            },
+            "time": "2023-04-15T19:07:00+00:00"
         }
     ],
     "aliases": [],

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -45,10 +45,11 @@ The first Giiken app-level class in normal boot is `Giiken\GiikenServiceProvider
 
 - `register()` contributes app entity types (`community`, `knowledge_item`, `wiki_lint_report`)
 - `register()` binds app services resolved by SSR `serviceResolver`: `CommunityRepositoryInterface`, `KnowledgeItemRepositoryInterface`, `SearchService`, `QaServiceInterface`, `ReportServiceInterface`, `ExportServiceInterface`, `SynthesisService`, dev `NullEmbeddingProvider` / `NullLlmProvider`, and a PSR-14 `EventDispatcherInterface` alias to the kernel dispatcher (for `EntityRepository` construction); registers `Giiken\Http\Inertia\InertiaHttpResponder` (full-page renderer from DI when present)
-- `register()` re-binds `InertiaFullPageRendererInterface` with a project-root-based `ViteAssetManager` (`public/build` manifest or `VITE_DEV_SERVER`), sets `Inertia::setVersion('giiken')`, and refreshes `Inertia::setRenderer(...)` so asset paths do not depend on `getcwd()`
+- `register()` re-binds `InertiaFullPageRendererInterface` with a project-root-based `ViteAssetManager` (`public/build` manifest or `VITE_DEV_SERVER`), sets `Inertia::setVersion('giiken')`, and refreshes `Inertia::setRenderer(...)` with a custom template closure that rewrites the data-page attribute from `data-page="true"` to `data-page="app"` so Inertia v2's client-side reader (`script[data-page="app"]`) actually finds the initial page object — workaround for waaseyaa/framework#1227
 - Frontend bundle: Vite entry `resources/js/app.ts`, production output under `public/build` (`npm run build`); set `VITE_DEV_SERVER` (e.g. `http://127.0.0.1:5173`) when using `npm run dev` for HMR
 - `commands()` contributes CLI commands (`giiken:seed:test-community`)
 - `routes()` contributes app HTTP routes (discovery, management, `GET`/`POST` `/login`, `GET` `/logout`)
+- `HomeController::discover` (`GET /`) injects `CommunityRepositoryInterface` and ships the result of `findAllPublic()` as the `communities` Inertia prop for `Pages/Discover.vue`, which renders a community card grid linking into `/{slug}` Discovery pages
 
 ### 1.4 Schema and local data
 

--- a/resources/js/Pages/Discover.vue
+++ b/resources/js/Pages/Discover.vue
@@ -1,6 +1,54 @@
-<template>
-  <h1>Discover</h1>
-</template>
-
 <script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+
+interface CommunitySummary {
+  id: number | string
+  name: string
+  slug: string
+  locale: string
+}
+
+defineProps<{
+  communities: CommunitySummary[]
+}>()
 </script>
+
+<template>
+  <div class="min-h-screen bg-bg">
+    <nav class="bg-indigo-dark text-white px-6 py-3">
+      <span class="font-bold text-lg">Giiken</span>
+    </nav>
+
+    <header class="bg-gradient-to-br from-indigo to-indigo-mid text-white py-20 px-6 text-center">
+      <h1 class="text-4xl font-bold mb-3">Sovereign Indigenous Knowledge</h1>
+      <p class="text-indigo-light text-lg max-w-2xl mx-auto">
+        Browse community knowledge bases. Each community governs its own content under its own protocols.
+      </p>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-6 py-12">
+      <h2 class="text-xl font-semibold text-indigo-dark mb-6">Communities</h2>
+
+      <div v-if="communities.length > 0" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Link
+          v-for="community in communities"
+          :key="community.id"
+          :href="`/${community.slug}`"
+          class="block p-5 bg-white rounded-lg border border-border hover:shadow-md hover:border-indigo transition"
+        >
+          <h3 class="font-semibold text-indigo-dark text-lg">{{ community.name }}</h3>
+          <p class="text-sm text-muted mt-1">/{{ community.slug }}</p>
+          <p class="text-xs text-muted mt-3 uppercase tracking-wide">{{ community.locale }}</p>
+        </Link>
+      </div>
+
+      <div v-else class="bg-white border border-border rounded-lg p-8 text-center">
+        <p class="text-muted">
+          No communities yet. Run
+          <code class="text-indigo bg-indigo-light px-2 py-0.5 rounded">./bin/waaseyaa giiken:seed:test-community</code>
+          to seed a demo community.
+        </p>
+      </div>
+    </main>
+  </div>
+</template>

--- a/src/Entity/Community/CommunityRepository.php
+++ b/src/Entity/Community/CommunityRepository.php
@@ -28,6 +28,16 @@ final class CommunityRepository implements CommunityRepositoryInterface
         return $entity instanceof Community ? $entity : null;
     }
 
+    public function findAllPublic(?int $limit = null): array
+    {
+        $results = $this->repository->findBy([], ['name' => 'ASC'], $limit);
+
+        return array_values(array_filter(
+            $results,
+            static fn ($entity): bool => $entity instanceof Community,
+        ));
+    }
+
     public function save(Community $community): void
     {
         $community->set('updated_at', CarbonImmutable::now()->toIso8601String());

--- a/src/Entity/Community/CommunityRepositoryInterface.php
+++ b/src/Entity/Community/CommunityRepositoryInterface.php
@@ -10,6 +10,11 @@ interface CommunityRepositoryInterface
 
     public function findBySlug(string $slug): ?Community;
 
+    /**
+     * @return list<Community>
+     */
+    public function findAllPublic(?int $limit = null): array;
+
     public function save(Community $community): void;
 
     public function delete(Community $community): void;

--- a/src/GiikenServiceProvider.php
+++ b/src/GiikenServiceProvider.php
@@ -209,7 +209,31 @@ final class GiikenServiceProvider extends ServiceProvider
             baseUrl: '',
             devServerUrl: $devServerUrl,
         );
-        $renderer = new RootTemplateRenderer(assetManager: $assetManager);
+
+        // Workaround for waaseyaa/inertia: framework renders <script data-page="true">,
+        // but Inertia v2's client reader queries for `script[data-page="app"]` (matching
+        // the el id). Rewrite the attribute so the page object actually mounts.
+        $template = static function (string $scriptTag) use ($assetManager): string {
+            $scriptTag = str_replace('data-page="true"', 'data-page="app"', $scriptTag);
+            $assetTags = $assetManager->assetTags();
+
+            return <<<HTML
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                {$assetTags}
+            </head>
+            <body>
+                <div id="app"></div>
+                {$scriptTag}
+            </body>
+            </html>
+            HTML;
+        };
+
+        $renderer = new RootTemplateRenderer(template: $template, assetManager: $assetManager);
         Inertia::setRenderer($renderer);
         Inertia::setVersion('giiken');
         $this->singleton(InertiaFullPageRendererInterface::class, static fn (): InertiaFullPageRendererInterface => $renderer);

--- a/src/Http/Controller/HomeController.php
+++ b/src/Http/Controller/HomeController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Giiken\Http\Controller;
 
+use Giiken\Entity\Community\Community;
+use Giiken\Entity\Community\CommunityRepositoryInterface;
 use Giiken\Http\Inertia\InertiaHttpResponder;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;
@@ -11,12 +13,13 @@ use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Inertia\Inertia;
 
 /**
- * Public landing route: Inertia {@see Discover} page (Phase 4 UX skeleton).
+ * Public landing route: Inertia Discover page listing communities.
  */
 final class HomeController
 {
     public function __construct(
         private readonly ?InertiaHttpResponder $inertiaHttp = null,
+        private readonly ?CommunityRepositoryInterface $communityRepo = null,
     ) {}
 
     /**
@@ -35,8 +38,20 @@ final class HomeController
             ]);
         }
 
+        $communities = $this->communityRepo === null
+            ? []
+            : array_map(
+                static fn (Community $c): array => [
+                    'id'     => $c->id(),
+                    'name'   => $c->name(),
+                    'slug'   => $c->slug(),
+                    'locale' => $c->locale(),
+                ],
+                $this->communityRepo->findAllPublic(),
+            );
+
         return $this->inertiaHttp->toResponse(
-            Inertia::render('Discover', []),
+            Inertia::render('Discover', ['communities' => $communities]),
             $httpRequest,
             $account,
         );

--- a/tests/Integration/Http/DiscoverPageTest.php
+++ b/tests/Integration/Http/DiscoverPageTest.php
@@ -30,6 +30,8 @@ final class DiscoverPageTest extends TestCase
         self::$kernel = new HttpKernel(self::$projectRoot);
         $boot = new \ReflectionMethod(AbstractKernel::class, 'boot');
         $boot->invoke(self::$kernel);
+
+        self::$kernel->getMigrator()->run(self::$kernel->getMigrationLoader()->loadAll());
     }
 
     public static function tearDownAfterClass(): void
@@ -50,8 +52,10 @@ final class DiscoverPageTest extends TestCase
         $content = (string) $response->getContent();
         self::assertStringContainsString('text/html', (string) $response->headers->get('Content-Type'));
         self::assertStringContainsString('"component":"Discover"', $content);
+        // Giiken rewrites data-page="true" → data-page="app" so Inertia v2's
+        // client reader (`script[data-page="app"]`) actually finds the page object.
         self::assertMatchesRegularExpression(
-            '/<script[^>]+data-page="true"[^>]*>/',
+            '/<script[^>]+data-page="app"[^>]*>/',
             $content,
         );
     }

--- a/tests/Unit/Export/ImportServiceTest.php
+++ b/tests/Unit/Export/ImportServiceTest.php
@@ -87,6 +87,11 @@ final class ImportServiceTest extends TestCase
                 return null;
             }
 
+            public function findAllPublic(?int $limit = null): array
+            {
+                return [];
+            }
+
             public function save(Community $community): void
             {
                 $community->set('id', $this->communityId);
@@ -135,6 +140,7 @@ final class ImportServiceTest extends TestCase
         $communityRepository = new class implements CommunityRepositoryInterface {
             public function find(string $id): ?Community { return null; }
             public function findBySlug(string $slug): ?Community { return null; }
+            public function findAllPublic(?int $limit = null): array { return []; }
             public function save(Community $community): void {}
             public function delete(Community $community): void {}
         };


### PR DESCRIPTION
Three commits that close out the boot-to-browser Phase A work: the composer merge-plugin so the local waaseyaa overlay actually resolves, the \`vendor/bin/waaseyaa\` symlink workaround so PHPUnit and \`./bin/waaseyaa\` agree on project root, and the Discover landing slice with the Inertia v2 \`data-page\` mount workaround.

## Commits

- \`211921a\` — add composer merge-plugin for local waaseyaa path overlay
- \`d0eb36a\` — symlink \`vendor/bin/waaseyaa\` to local wrapper, refresh boot-to-browser status (#53)
- \`58cd892\` — Discover landing + Inertia \`data-page\` workaround (#54)

See \`CLAUDE.md\` § Boot-to-browser status for the narrative on what works end-to-end today (boot, migrate, seed, SSR dispatch through Inertia).

## Test plan

- [ ] \`./vendor/bin/phpunit\` — 198/198 green at this commit.
- [ ] \`./bin/waaseyaa migrate && ./bin/waaseyaa giiken:seed:test-community\` against a fresh \`storage/waaseyaa.sqlite\`.
- [ ] \`curl -s http://127.0.0.1:8181/\` and \`.../test-community\` both return 200 with Inertia \`data-page="app"\` markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)