### PR TITLE
refactor(#64): rename CommunityRepository::findAllPublic to findAll

### DIFF
--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -49,7 +49,7 @@ The first Giiken app-level class in normal boot is `Giiken\GiikenServiceProvider
 - Frontend bundle: Vite entry `resources/js/app.ts`, production output under `public/build` (`npm run build`); set `VITE_DEV_SERVER` (e.g. `http://127.0.0.1:5173`) when using `npm run dev` for HMR
 - `commands()` contributes CLI commands (`giiken:seed:test-community`)
 - `routes()` contributes app HTTP routes (discovery, management, `GET`/`POST` `/login`, `GET` `/logout`)
-- `HomeController::discover` (`GET /`) injects `CommunityRepositoryInterface` and ships the result of `findAllPublic()` as the `communities` Inertia prop for `Pages/Discover.vue`, which renders a community card grid linking into `/{slug}` Discovery pages
+- `HomeController::discover` (`GET /`) injects `CommunityRepositoryInterface` and ships the result of `findAll()` as the `communities` Inertia prop for `Pages/Discover.vue`, which renders a community card grid linking into `/{slug}` Discovery pages
 
 ### 1.4 Schema and local data
 

--- a/src/Entity/Community/CommunityRepository.php
+++ b/src/Entity/Community/CommunityRepository.php
@@ -28,7 +28,7 @@ final class CommunityRepository implements CommunityRepositoryInterface
         return $entity instanceof Community ? $entity : null;
     }
 
-    public function findAllPublic(?int $limit = null): array
+    public function findAll(?int $limit = null): array
     {
         $results = $this->repository->findBy([], ['name' => 'ASC'], $limit);
 

--- a/src/Entity/Community/CommunityRepositoryInterface.php
+++ b/src/Entity/Community/CommunityRepositoryInterface.php
@@ -11,9 +11,15 @@ interface CommunityRepositoryInterface
     public function findBySlug(string $slug): ?Community;
 
     /**
+     * Return every community in the table, name-sorted. The method intentionally
+     * has no visibility filter: Giiken has no concept of private/draft
+     * communities yet, so introducing one now would be speculative. When a
+     * real visibility flag lands, either add a new filtered method alongside
+     * this one or add a `visibility` parameter here. See waaseyaa/giiken#64.
+     *
      * @return list<Community>
      */
-    public function findAllPublic(?int $limit = null): array;
+    public function findAll(?int $limit = null): array;
 
     public function save(Community $community): void;
 

--- a/src/Http/Controller/HomeController.php
+++ b/src/Http/Controller/HomeController.php
@@ -47,7 +47,7 @@ final class HomeController
                     'slug'   => $c->slug(),
                     'locale' => $c->locale(),
                 ],
-                $this->communityRepo->findAllPublic(),
+                $this->communityRepo->findAll(),
             );
 
         return $this->inertiaHttp->toResponse(

--- a/tests/Unit/Export/ImportServiceTest.php
+++ b/tests/Unit/Export/ImportServiceTest.php
@@ -87,7 +87,7 @@ final class ImportServiceTest extends TestCase
                 return null;
             }
 
-            public function findAllPublic(?int $limit = null): array
+            public function findAll(?int $limit = null): array
             {
                 return [];
             }
@@ -140,7 +140,7 @@ final class ImportServiceTest extends TestCase
         $communityRepository = new class implements CommunityRepositoryInterface {
             public function find(string $id): ?Community { return null; }
             public function findBySlug(string $slug): ?Community { return null; }
-            public function findAllPublic(?int $limit = null): array { return []; }
+            public function findAll(?int $limit = null): array { return []; }
             public function save(Community $community): void {}
             public function delete(Community $community): void {}
         };


### PR DESCRIPTION
## Summary
- `CommunityRepository::findAllPublic()` promised public-only visibility but passed an empty filter. Renamed to `findAll()` to match actual behavior.
- YAGNI: Giiken has no concept of private/draft communities yet. When real visibility lands, we'll add a filtered variant alongside rather than pretending the old one existed all along. Interface docblock records this decision.
- Interface, implementation, `HomeController::discover` call site, two anonymous-class mocks in `ImportServiceTest`, and lifecycle doc § 2.2 all updated.

Closes #64.

## Test plan
- [x] All 215 PHPUnit tests green.
- [x] `phpstan analyse src/` clean.
- [x] Lifecycle drift check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)