### PR TITLE
refactor(#65): extract composer post-install hook to standalone script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ PHPUnit: 198/198 passing.
 
 `./bin/waaseyaa` is the giiken-local entry that loads `.env` and uses the project root. By default, composer installs `vendor/bin/waaseyaa` as a proxy to the `waaseyaa/cli` package's bin, which does **not** load `.env` and resolves `projectRoot` relative to its own vendor location — that path lands in `vendor/waaseyaa/cli/storage/waaseyaa.sqlite` and falls through to `APP_ENV=production`, tripping the `DatabaseBootstrapper` "must already exist" guard.
 
-To make both invocations equivalent, `composer.json` runs a `post-install-cmd` / `post-update-cmd` that replaces `vendor/bin/waaseyaa` with a symlink to `../../bin/waaseyaa`. After any `composer install` / `composer update`, both `./bin/waaseyaa` and `./vendor/bin/waaseyaa` point at the same wrapper. This is a workaround for waaseyaa/framework#1226 — once that lands, the symlink hook can be removed.
+To make both invocations equivalent, `composer.json` runs a `post-install-cmd` / `post-update-cmd` that invokes `scripts/repoint-vendor-bin.php`, which replaces `vendor/bin/waaseyaa` with a symlink to `../../bin/waaseyaa`. The script is idempotent — safe to re-run. After any `composer install` / `composer update`, both `./bin/waaseyaa` and `./vendor/bin/waaseyaa` point at the same wrapper. This is a workaround for waaseyaa/framework#1226; once that lands, delete `scripts/repoint-vendor-bin.php`, the two composer hook entries, and this paragraph.
 
 ## Commands
 

--- a/composer.json
+++ b/composer.json
@@ -65,10 +65,10 @@
         "dev": "php bin/waaseyaa serve",
         "test": "./vendor/bin/phpunit",
         "post-install-cmd": [
-            "@php -r \"if (file_exists('bin/waaseyaa') && is_dir('vendor/bin')) { @unlink('vendor/bin/waaseyaa'); symlink('../../bin/waaseyaa', 'vendor/bin/waaseyaa'); echo \\\"Repointed vendor/bin/waaseyaa -> bin/waaseyaa\\n\\\"; }\""
+            "@php scripts/repoint-vendor-bin.php"
         ],
         "post-update-cmd": [
-            "@php -r \"if (file_exists('bin/waaseyaa') && is_dir('vendor/bin')) { @unlink('vendor/bin/waaseyaa'); symlink('../../bin/waaseyaa', 'vendor/bin/waaseyaa'); echo \\\"Repointed vendor/bin/waaseyaa -> bin/waaseyaa\\n\\\"; }\""
+            "@php scripts/repoint-vendor-bin.php"
         ]
     },
     "extra": {

--- a/scripts/repoint-vendor-bin.php
+++ b/scripts/repoint-vendor-bin.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Repoint vendor/bin/waaseyaa at the giiken-local wrapper (bin/waaseyaa).
+ *
+ * Composer installs vendor/bin/waaseyaa as a proxy to the waaseyaa/cli
+ * package's bin, which does not load .env and resolves projectRoot relative
+ * to its own vendor location. That path lands in
+ * vendor/waaseyaa/cli/storage/waaseyaa.sqlite and falls through to
+ * APP_ENV=production, tripping the DatabaseBootstrapper "must already
+ * exist" guard.
+ *
+ * This script runs from composer's post-install-cmd / post-update-cmd and
+ * replaces vendor/bin/waaseyaa with a symlink pointing at ../../bin/waaseyaa
+ * so both invocations (./bin/waaseyaa and ./vendor/bin/waaseyaa) resolve to
+ * the same .env-loading wrapper.
+ *
+ * Idempotent: safe to run repeatedly. Becomes a one-line delete once
+ * waaseyaa/framework#1226 lands. See waaseyaa/giiken#65.
+ */
+
+$projectRoot = dirname(__DIR__);
+$wrapper     = $projectRoot . '/bin/waaseyaa';
+$vendorBin   = $projectRoot . '/vendor/bin';
+$target      = $vendorBin . '/waaseyaa';
+$linkDest    = '../../bin/waaseyaa';
+
+if (!file_exists($wrapper)) {
+    fwrite(STDERR, "repoint-vendor-bin: bin/waaseyaa does not exist; skipping.\n");
+    exit(0);
+}
+
+if (!is_dir($vendorBin)) {
+    fwrite(STDERR, "repoint-vendor-bin: vendor/bin does not exist; skipping.\n");
+    exit(0);
+}
+
+if (is_link($target) && readlink($target) === $linkDest) {
+    echo "repoint-vendor-bin: vendor/bin/waaseyaa already points at {$linkDest}\n";
+    exit(0);
+}
+
+@unlink($target);
+
+if (!symlink($linkDest, $target)) {
+    fwrite(STDERR, "repoint-vendor-bin: failed to create symlink at {$target}\n");
+    exit(1);
+}
+
+echo "repoint-vendor-bin: vendor/bin/waaseyaa -> {$linkDest}\n";


### PR DESCRIPTION
## Summary
The double-escaped inline \`@php -r \"...\"\` string in \`composer.json\`'s \`post-install-cmd\` / \`post-update-cmd\` was correct but fiddly and unlintable. Moved to \`scripts/repoint-vendor-bin.php\`.

The new script is idempotent: if \`vendor/bin/waaseyaa\` already points at \`../../bin/waaseyaa\` it short-circuits with a message. It also skips cleanly when \`bin/waaseyaa\` or \`vendor/bin\` is missing, and exits non-zero only when \`symlink()\` itself fails.

CLAUDE.md boot-to-browser note updated to reference the script and to list it in the removal instructions for waaseyaa/framework#1226.

Closes #65.

## Test plan
- [x] Local: deleted \`vendor/bin/waaseyaa\`, ran the script, symlink recreated.
- [x] Local: ran the script a second time, got the idempotent message.
- [x] Local: \`composer run-script post-install-cmd\` runs the script via the new hook entry.
- [x] Local: \`./vendor/bin/waaseyaa list\` resolves through the new symlink.
- [x] 215 PHPUnit tests green.
- [x] \`phpstan analyse src/\` clean.
- [x] Lifecycle drift check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)