### PR TITLE
feat(#15): semantic design tokens (step 1 of 2)

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,11 +1,42 @@
 @import "tailwindcss";
 
 @theme {
+  /* Semantic role tokens — use these in new code. */
+  --color-surface: #f8f8fd;
+  --color-surface-raised: #ffffff;
+  --color-surface-inverse: #1a1a2e;
+
+  --color-ink: #1a1a2e;
+  --color-ink-muted: #9090b0;
+  --color-on-inverse: #ffffff;
+  --color-on-primary: #ffffff;
+
+  --color-primary: #3d35c8;
+  --color-primary-hover: #6e66ff;
+  --color-primary-subtle: #f0f0ff;
+
+  --color-border: #e8eaf0;
+
+  --color-danger: #991b1b;
+  --color-danger-border: #f87171;
+  --color-danger-subtle: #fef2f2;
+
+  --color-type-cultural-bg: #f0f0ff;
+  --color-type-cultural-text: #3d35c8;
+  --color-type-governance-bg: #e8f5f0;
+  --color-type-governance-text: #1e8a6e;
+  --color-type-land-bg: #edf2e8;
+  --color-type-land-text: #4a7a3a;
+  --color-type-relationship-bg: #fff0f5;
+  --color-type-relationship-text: #c83568;
+  --color-type-event-bg: #fff8e8;
+  --color-type-event-text: #c89a35;
+
+  /* Legacy aliases — kept for in-flight migration, will be removed. */
   --color-indigo: #3d35c8;
   --color-indigo-dark: #1a1a2e;
   --color-indigo-light: #f0f0ff;
   --color-indigo-mid: #6e66ff;
   --color-muted: #9090b0;
-  --color-border: #e8eaf0;
   --color-bg: #f8f8fd;
 }

--- a/resources/js/Components/AnswerPanel.vue
+++ b/resources/js/Components/AnswerPanel.vue
@@ -68,27 +68,27 @@ const shouldRenderNoAnswer = computed(
 <template>
   <NoAnswerState v-if="shouldRenderNoAnswer" />
 
-  <div v-else class="bg-white rounded-lg border border-border p-6">
+  <div v-else class="bg-surface-raised rounded-lg border border-border p-6">
     <div class="flex items-center gap-2 mb-4">
-      <span class="w-2.5 h-2.5 bg-indigo rounded-full" />
-      <span class="font-semibold text-indigo-dark">Answer</span>
-      <span class="text-xs text-muted">{{ answerLabel }}</span>
+      <span class="w-2.5 h-2.5 bg-primary rounded-full" />
+      <span class="font-semibold text-ink">Answer</span>
+      <span class="text-xs text-ink-muted">{{ answerLabel }}</span>
     </div>
 
     <div v-if="loading" data-test="answer-loading" class="space-y-3">
-      <div class="h-4 bg-bg rounded animate-pulse" />
-      <div class="h-4 bg-bg rounded animate-pulse w-11/12" />
-      <div class="h-4 bg-bg rounded animate-pulse w-3/4" />
+      <div class="h-4 bg-surface rounded animate-pulse" />
+      <div class="h-4 bg-surface rounded animate-pulse w-11/12" />
+      <div class="h-4 bg-surface rounded animate-pulse w-3/4" />
     </div>
 
     <div v-else>
-      <p class="text-indigo-dark whitespace-pre-line leading-relaxed">
+      <p class="text-ink whitespace-pre-line leading-relaxed">
         <template v-for="(part, i) in answerParts" :key="i">
           <template v-if="part.kind === 'text'">{{ part.text }}</template>
           <sup v-else class="mx-0.5">
             <a
               :href="`#citation-${part.index}`"
-              class="text-indigo font-semibold no-underline hover:underline"
+              class="text-primary font-semibold no-underline hover:underline"
               >[{{ part.index }}]</a
             >
           </sup>
@@ -96,7 +96,7 @@ const shouldRenderNoAnswer = computed(
       </p>
 
       <div v-if="citations.length > 0" class="mt-6 pt-4 border-t border-border">
-        <p class="text-sm font-medium text-muted mb-2">Sources</p>
+        <p class="text-sm font-medium text-ink-muted mb-2">Sources</p>
         <div class="space-y-2">
           <CitationCard
             v-for="(citation, idx) in citations"

--- a/resources/js/Components/CitationCard.vue
+++ b/resources/js/Components/CitationCard.vue
@@ -24,17 +24,17 @@ function toggle() {
 <template>
   <div
     :id="`citation-${index}`"
-    class="border border-border rounded bg-bg overflow-hidden"
+    class="border border-border rounded bg-surface overflow-hidden"
   >
     <button
       type="button"
-      class="w-full flex items-start gap-2 text-left p-3 hover:bg-white transition-colors"
+      class="w-full flex items-start gap-2 text-left p-3 hover:bg-surface-raised transition-colors"
       :aria-expanded="expanded"
       :aria-controls="`citation-${index}-body`"
       @click="toggle"
     >
-      <span class="text-indigo font-medium shrink-0">[{{ index }}]</span>
-      <span class="font-medium text-indigo-dark flex-1 min-w-0 truncate">{{ citation.title }}</span>
+      <span class="text-primary font-medium shrink-0">[{{ index }}]</span>
+      <span class="font-medium text-ink flex-1 min-w-0 truncate">{{ citation.title }}</span>
       <span
         v-if="typeConfig"
         class="text-xs px-2 py-0.5 rounded-full shrink-0"
@@ -42,18 +42,18 @@ function toggle() {
       >
         {{ typeConfig.label }}
       </span>
-      <span class="text-xs text-muted shrink-0">{{ expanded ? '−' : '+' }}</span>
+      <span class="text-xs text-ink-muted shrink-0">{{ expanded ? '−' : '+' }}</span>
     </button>
 
     <div
       v-if="expanded"
       :id="`citation-${index}-body`"
-      class="px-3 pb-3 pt-0 border-t border-border bg-white"
+      class="px-3 pb-3 pt-0 border-t border-border bg-surface-raised"
     >
-      <p class="text-sm text-indigo-dark whitespace-pre-line">{{ citation.excerpt }}</p>
+      <p class="text-sm text-ink whitespace-pre-line">{{ citation.excerpt }}</p>
       <Link
         :href="`/${communitySlug}/item/${citation.itemId}`"
-        class="inline-block text-xs text-indigo hover:underline mt-2"
+        class="inline-block text-xs text-primary hover:underline mt-2"
       >
         Open full item →
       </Link>

--- a/resources/js/Layouts/DiscoveryLayout.vue
+++ b/resources/js/Layouts/DiscoveryLayout.vue
@@ -9,13 +9,13 @@ const props = defineProps<{
 </script>
 
 <template>
-  <div class="min-h-screen bg-bg">
-    <nav class="bg-indigo-dark text-white px-6 py-3 flex items-center justify-between">
+  <div class="min-h-screen bg-surface">
+    <nav class="bg-surface-inverse text-on-inverse px-6 py-3 flex items-center justify-between">
       <div class="flex items-center gap-6">
         <span class="font-bold text-lg">{{ community.name }}</span>
         <div class="flex gap-4 text-sm">
-          <Link :href="`/${community.slug}`" class="hover:text-indigo-light">Discover</Link>
-          <Link :href="`/${community.slug}/manage`" class="hover:text-indigo-light" v-if="showManagement">⚙ Management</Link>
+          <Link :href="`/${community.slug}`" class="hover:text-primary-subtle">Discover</Link>
+          <Link :href="`/${community.slug}/manage`" class="hover:text-primary-subtle" v-if="showManagement">⚙ Management</Link>
         </div>
       </div>
     </nav>

--- a/resources/js/Layouts/ManagementLayout.vue
+++ b/resources/js/Layouts/ManagementLayout.vue
@@ -6,8 +6,8 @@ defineProps<{ community: Community }>()
 </script>
 
 <template>
-  <div class="min-h-screen bg-bg flex">
-    <aside class="w-56 bg-indigo-dark text-white flex flex-col shrink-0">
+  <div class="min-h-screen bg-surface flex">
+    <aside class="w-56 bg-surface-inverse text-on-inverse flex flex-col shrink-0">
       <div class="px-4 py-5 border-b border-white/10">
         <span class="font-bold text-sm">{{ community.name }}</span>
       </div>

--- a/resources/js/Pages/Discover.vue
+++ b/resources/js/Pages/Discover.vue
@@ -14,38 +14,38 @@ defineProps<{
 </script>
 
 <template>
-  <div class="min-h-screen bg-bg">
-    <nav class="bg-indigo-dark text-white px-6 py-3">
+  <div class="min-h-screen bg-surface">
+    <nav class="bg-surface-inverse text-on-inverse px-6 py-3">
       <span class="font-bold text-lg">Giiken</span>
     </nav>
 
-    <header class="bg-gradient-to-br from-indigo to-indigo-mid text-white py-20 px-6 text-center">
+    <header class="bg-gradient-to-br from-primary to-primary-hover text-on-primary py-20 px-6 text-center">
       <h1 class="text-4xl font-bold mb-3">Sovereign Indigenous Knowledge</h1>
-      <p class="text-indigo-light text-lg max-w-2xl mx-auto">
+      <p class="text-primary-subtle text-lg max-w-2xl mx-auto">
         Browse community knowledge bases. Each community governs its own content under its own protocols.
       </p>
     </header>
 
     <main class="max-w-5xl mx-auto px-6 py-12">
-      <h2 class="text-xl font-semibold text-indigo-dark mb-6">Communities</h2>
+      <h2 class="text-xl font-semibold text-ink mb-6">Communities</h2>
 
       <div v-if="communities.length > 0" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <Link
           v-for="community in communities"
           :key="community.id"
           :href="`/${community.slug}`"
-          class="block p-5 bg-white rounded-lg border border-border hover:shadow-md hover:border-indigo transition"
+          class="block p-5 bg-surface-raised rounded-lg border border-border hover:shadow-md hover:border-primary transition"
         >
-          <h3 class="font-semibold text-indigo-dark text-lg">{{ community.name }}</h3>
-          <p class="text-sm text-muted mt-1">/{{ community.slug }}</p>
-          <p class="text-xs text-muted mt-3 uppercase tracking-wide">{{ community.locale }}</p>
+          <h3 class="font-semibold text-ink text-lg">{{ community.name }}</h3>
+          <p class="text-sm text-ink-muted mt-1">/{{ community.slug }}</p>
+          <p class="text-xs text-ink-muted mt-3 uppercase tracking-wide">{{ community.locale }}</p>
         </Link>
       </div>
 
-      <div v-else class="bg-white border border-border rounded-lg p-8 text-center">
-        <p class="text-muted">
+      <div v-else class="bg-surface-raised border border-border rounded-lg p-8 text-center">
+        <p class="text-ink-muted">
           No communities yet. Run
-          <code class="text-indigo bg-indigo-light px-2 py-0.5 rounded">./bin/waaseyaa giiken:seed:test-community</code>
+          <code class="text-primary bg-primary-subtle px-2 py-0.5 rounded">./bin/waaseyaa giiken:seed:test-community</code>
           to seed a demo community.
         </p>
       </div>

--- a/resources/js/Pages/Management/Ingestion.vue
+++ b/resources/js/Pages/Management/Ingestion.vue
@@ -38,15 +38,15 @@ function onFileChange(event: Event) {
 
 <template>
   <ManagementLayout :community="community">
-    <h1 class="text-2xl font-bold text-indigo-dark mb-6">Ingestion Queue</h1>
+    <h1 class="text-2xl font-bold text-ink mb-6">Ingestion Queue</h1>
 
     <div v-if="bootError" class="mb-4 p-3 border border-amber-400 bg-amber-50 text-amber-900 rounded">
       {{ bootError }}
     </div>
 
-    <section class="mb-8 p-4 border border-border rounded bg-white">
-      <h2 class="text-lg font-semibold text-indigo-dark mb-3">Upload a file</h2>
-      <p class="text-sm text-muted mb-4">
+    <section class="mb-8 p-4 border border-border rounded bg-surface-raised">
+      <h2 class="text-lg font-semibold text-ink mb-3">Upload a file</h2>
+      <p class="text-sm text-ink-muted mb-4">
         Markdown, CSV, HTML, Word/PDF documents, and audio/video files are accepted.
         Audio and video files are queued for transcription.
       </p>
@@ -61,7 +61,7 @@ function onFileChange(event: Event) {
         <div>
           <button
             type="submit"
-            class="px-4 py-2 bg-indigo text-white rounded disabled:opacity-50"
+            class="px-4 py-2 bg-primary text-on-primary rounded disabled:opacity-50"
             :disabled="form.processing || !form.file"
           >
             {{ form.processing ? 'Uploading…' : 'Upload' }}
@@ -69,7 +69,7 @@ function onFileChange(event: Event) {
         </div>
       </form>
 
-      <div v-if="uploadError" class="mt-4 p-3 border border-red-400 bg-red-50 text-red-900 rounded text-sm">
+      <div v-if="uploadError" class="mt-4 p-3 border border-danger-border bg-danger-subtle text-danger rounded text-sm">
         {{ uploadError }}
       </div>
 
@@ -84,7 +84,7 @@ function onFileChange(event: Event) {
       </div>
     </section>
 
-    <p class="text-muted text-sm">
+    <p class="text-ink-muted text-sm">
       Pipeline status display will be wired when the queue service is integrated.
     </p>
   </ManagementLayout>


### PR DESCRIPTION
## Summary

- Adds a semantic token layer to `resources/css/app.css` (`surface`, `ink`, `primary`, `on-*`, `danger`, `type-*`) alongside the existing literal `indigo-*` aliases — no breakage for unmigrated files.
- Migrates the 5 heaviest files + both layouts to the new names: `Pages/Discover`, `Pages/Management/Ingestion`, `Layouts/Management`, `Layouts/Discovery`, `Components/CitationCard`, `Components/AnswerPanel`.
- Refs #15. Unblocks #16 (theming) and the management-panel work in #20–22 — dark mode becomes a single theme-file swap instead of a global rename.

## Scope decision

Intentionally **step 1 of 2**. Left for the follow-up PR so you can eyeball the heavy pages first:

- Light files: `NoAnswerState`, `SearchInput`, `Pagination`, `KnowledgeCard`, `ReportCard`, `TypeFilter`, `Pages/Discovery/{Ask,Search,Index,Show}`, `Pages/Management/{Dashboard,Users,Reports,Export}`
- Knowledge-type palette in `resources/js/types.ts` (still inline hex via `:style` — requires changing `KNOWLEDGE_TYPE_CONFIG` shape, which ripples into `KnowledgeCard`, `Discovery/Show`, `TypeFilter`)
- `resources/js/app.ts` Inertia progress hex
- Legacy `--color-indigo*` / `--color-muted` / `--color-bg` aliases — removed in step 2 once the migration is complete

## Token map used

| Legacy | Semantic |
|---|---|
| `bg-bg` | `bg-surface` |
| `bg-white` | `bg-surface-raised` |
| `bg-indigo-dark` | `bg-surface-inverse` |
| `text-indigo-dark` | `text-ink` |
| `text-muted` | `text-ink-muted` |
| `text-white` (on inverse) | `text-on-inverse` / `text-on-primary` |
| `bg-indigo` | `bg-primary` |
| `text-indigo` | `text-primary` |
| `bg-indigo-light` | `bg-primary-subtle` |
| `bg-indigo-mid` / `to-indigo-mid` | `bg-primary-hover` / `to-primary-hover` |
| `text-indigo-light` | `text-primary-subtle` |
| `from-indigo` | `from-primary` |
| `text-red-900` / `border-red-400` / `bg-red-50` | `text-danger` / `border-danger-border` / `bg-danger-subtle` |

`white/10` and `white/50` overlay classes on the inverse sidebar kept as-is — they're opacity modifiers, not brand colors.

## Test plan

- [x] `npx vue-tsc --noEmit` — clean
- [x] `npm run test:js` — 19/19 pass
- [x] `npm run build` — production build succeeds
- [ ] Eyeball `/`, `/{community}`, `/{community}/manage`, `/{community}/manage/ingestion` in a browser — the 5 heavy pages should look visually identical to main
- [ ] Confirm dark sidebar hover states still contrast (ManagementLayout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)