### PR TITLE
feat(#15): design tokens — step 2 (light files, KNOWLEDGE_TYPE_CONFIG, alias retirement)

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -34,7 +34,12 @@
 
   /* Knowledge-type palette. Each type has a saturated colour for active
      states and text, and a subtle colour for backgrounds.
-     Consumed by KNOWLEDGE_TYPE_CONFIG in resources/js/types.ts. */
+     Consumed by KNOWLEDGE_TYPE_CONFIG in resources/js/types.ts.
+     NOTE: --color-cultural intentionally duplicates --color-primary's
+     hex. Tailwind v4 @theme resolves tokens eagerly and does not support
+     var() references between tokens, so the value has to repeat. A
+     community theme that decouples cultural from primary should set
+     both independently. */
   --color-cultural: #3d35c8;
   --color-cultural-subtle: #f0f0ff;
   --color-governance: #1e8a6e;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,42 +1,48 @@
 @import "tailwindcss";
 
 @theme {
-  /* Semantic role tokens — use these in new code. */
+  /* Surfaces */
   --color-surface: #f8f8fd;
   --color-surface-raised: #ffffff;
   --color-surface-inverse: #1a1a2e;
 
+  /* Text.
+     --color-ink and --color-surface-inverse share #1a1a2e today because
+     the default theme uses the same shade for body text and the dark
+     sidebar/topbar. If a community theme diverges them, update both. */
   --color-ink: #1a1a2e;
   --color-ink-muted: #9090b0;
+
+  /* Text over non-default surfaces. Distinct roles even though both
+     resolve to white today: on-inverse is for dark chrome, on-primary is
+     for primary-coloured actions (buttons, badges, gradients). Theming
+     may push them apart. */
   --color-on-inverse: #ffffff;
   --color-on-primary: #ffffff;
 
+  /* Primary brand */
   --color-primary: #3d35c8;
   --color-primary-hover: #6e66ff;
   --color-primary-subtle: #f0f0ff;
 
   --color-border: #e8eaf0;
 
+  /* Status — danger only for now. Add warning/success/info as usages arise. */
   --color-danger: #991b1b;
   --color-danger-border: #f87171;
   --color-danger-subtle: #fef2f2;
 
-  --color-type-cultural-bg: #f0f0ff;
-  --color-type-cultural-text: #3d35c8;
-  --color-type-governance-bg: #e8f5f0;
-  --color-type-governance-text: #1e8a6e;
-  --color-type-land-bg: #edf2e8;
-  --color-type-land-text: #4a7a3a;
-  --color-type-relationship-bg: #fff0f5;
-  --color-type-relationship-text: #c83568;
-  --color-type-event-bg: #fff8e8;
-  --color-type-event-text: #c89a35;
-
-  /* Legacy aliases — kept for in-flight migration, will be removed. */
-  --color-indigo: #3d35c8;
-  --color-indigo-dark: #1a1a2e;
-  --color-indigo-light: #f0f0ff;
-  --color-indigo-mid: #6e66ff;
-  --color-muted: #9090b0;
-  --color-bg: #f8f8fd;
+  /* Knowledge-type palette. Each type has a saturated colour for active
+     states and text, and a subtle colour for backgrounds.
+     Consumed by KNOWLEDGE_TYPE_CONFIG in resources/js/types.ts. */
+  --color-cultural: #3d35c8;
+  --color-cultural-subtle: #f0f0ff;
+  --color-governance: #1e8a6e;
+  --color-governance-subtle: #e8f5f0;
+  --color-land: #4a7a3a;
+  --color-land-subtle: #edf2e8;
+  --color-relationship: #c83568;
+  --color-relationship-subtle: #fff0f5;
+  --color-event: #c89a35;
+  --color-event-subtle: #fff8e8;
 }

--- a/resources/js/Components/CitationCard.vue
+++ b/resources/js/Components/CitationCard.vue
@@ -38,7 +38,7 @@ function toggle() {
       <span
         v-if="typeConfig"
         class="text-xs px-2 py-0.5 rounded-full shrink-0"
-        :style="{ backgroundColor: typeConfig.bg, color: typeConfig.text }"
+        :class="typeConfig.chip"
       >
         {{ typeConfig.label }}
       </span>

--- a/resources/js/Components/KnowledgeCard.vue
+++ b/resources/js/Components/KnowledgeCard.vue
@@ -15,20 +15,20 @@ const typeConfig = props.knowledgeType ? KNOWLEDGE_TYPE_CONFIG[props.knowledgeTy
 </script>
 
 <template>
-  <Link :href="`/${communitySlug}/item/${id}`" class="block p-4 bg-white rounded-lg border border-border hover:shadow-md transition-shadow">
+  <Link :href="`/${communitySlug}/item/${id}`" class="block p-4 bg-surface-raised rounded-lg border border-border hover:shadow-md transition-shadow">
     <div class="flex items-start gap-3">
       <div
         v-if="typeConfig"
         class="w-3 h-3 rounded-full mt-1.5 shrink-0"
-        :style="{ backgroundColor: typeConfig.text }"
+        :class="typeConfig.dot"
       />
       <div class="min-w-0">
-        <h3 class="font-semibold text-indigo-dark truncate">{{ title }}</h3>
-        <p class="text-sm text-muted mt-1 line-clamp-2">{{ summary }}</p>
+        <h3 class="font-semibold text-ink truncate">{{ title }}</h3>
+        <p class="text-sm text-ink-muted mt-1 line-clamp-2">{{ summary }}</p>
         <span
           v-if="typeConfig"
           class="inline-block text-xs px-2 py-0.5 rounded-full mt-2"
-          :style="{ backgroundColor: typeConfig.bg, color: typeConfig.text }"
+          :class="typeConfig.chip"
         >
           {{ typeConfig.label }}
         </span>

--- a/resources/js/Components/NoAnswerState.vue
+++ b/resources/js/Components/NoAnswerState.vue
@@ -5,9 +5,9 @@
 </script>
 
 <template>
-  <div class="bg-white rounded-lg border border-border p-6 text-center">
-    <p class="text-indigo-dark font-medium mb-1">No information found</p>
-    <p class="text-sm text-muted italic">
+  <div class="bg-surface-raised rounded-lg border border-border p-6 text-center">
+    <p class="text-ink font-medium mb-1">No information found</p>
+    <p class="text-sm text-ink-muted italic">
       I could not find information about this in the community's knowledge base.
     </p>
   </div>

--- a/resources/js/Components/Pagination.vue
+++ b/resources/js/Components/Pagination.vue
@@ -23,7 +23,7 @@ function pageUrl(page: number): string {
       :key="page"
       :href="pageUrl(page)"
       class="px-3 py-1.5 rounded text-sm"
-      :class="page === currentPage ? 'bg-indigo text-white' : 'bg-indigo-light text-indigo hover:bg-indigo hover:text-white'"
+      :class="page === currentPage ? 'bg-primary text-on-primary' : 'bg-primary-subtle text-primary hover:bg-primary hover:text-on-primary'"
     >
       {{ page }}
     </Link>

--- a/resources/js/Components/ReportCard.vue
+++ b/resources/js/Components/ReportCard.vue
@@ -11,9 +11,9 @@ const emit = defineEmits<{ generate: [type: string] }>()
 <template>
   <button
     @click="emit('generate', type)"
-    class="p-5 bg-white rounded-lg border border-border hover:shadow-md transition-shadow text-left w-full"
+    class="p-5 bg-surface-raised rounded-lg border border-border hover:shadow-md transition-shadow text-left w-full"
   >
-    <h3 class="font-semibold text-indigo-dark">{{ title }}</h3>
-    <p class="text-sm text-muted mt-1">{{ description }}</p>
+    <h3 class="font-semibold text-ink">{{ title }}</h3>
+    <p class="text-sm text-ink-muted mt-1">{{ description }}</p>
   </button>
 </template>

--- a/resources/js/Components/SearchInput.vue
+++ b/resources/js/Components/SearchInput.vue
@@ -28,9 +28,9 @@ function submit() {
       v-model="query"
       type="text"
       placeholder="Search or ask a question..."
-      class="flex-1 px-4 py-3 rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-indigo text-base"
+      class="flex-1 px-4 py-3 rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary text-base"
     />
-    <button type="submit" class="px-6 py-3 bg-indigo text-white rounded-lg hover:bg-indigo-mid font-medium">
+    <button type="submit" class="px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover font-medium">
       Ask →
     </button>
   </form>

--- a/resources/js/Components/TypeFilter.vue
+++ b/resources/js/Components/TypeFilter.vue
@@ -6,13 +6,24 @@ defineProps<{ active: KnowledgeType | null }>()
 const emit = defineEmits<{ select: [type: KnowledgeType | null] }>()
 
 const types = Object.entries(KNOWLEDGE_TYPE_CONFIG) as [KnowledgeType, typeof KNOWLEDGE_TYPE_CONFIG[KnowledgeType]][]
+
+// Active-state class for each type button. Uses the saturated type colour
+// as the background with on-primary text, so the active pill inverts from
+// the default chip styling.
+const activeClass: Record<KnowledgeType, string> = {
+  cultural: 'bg-cultural text-on-primary',
+  governance: 'bg-governance text-on-primary',
+  land: 'bg-land text-on-primary',
+  relationship: 'bg-relationship text-on-primary',
+  event: 'bg-event text-on-primary',
+}
 </script>
 
 <template>
   <div class="flex gap-2 flex-wrap">
     <button
       class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
-      :class="active === null ? 'bg-indigo text-white' : 'bg-indigo-light text-indigo'"
+      :class="active === null ? 'bg-primary text-on-primary' : 'bg-primary-subtle text-primary'"
       @click="emit('select', null)"
     >
       All
@@ -21,9 +32,7 @@ const types = Object.entries(KNOWLEDGE_TYPE_CONFIG) as [KnowledgeType, typeof KN
       v-for="[type, config] in types"
       :key="type"
       class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
-      :style="active === type
-        ? { backgroundColor: config.text, color: 'white' }
-        : { backgroundColor: config.bg, color: config.text }"
+      :class="active === type ? activeClass[type] : config.chip"
       @click="emit('select', type)"
     >
       {{ config.label }}

--- a/resources/js/Components/TypeFilter.vue
+++ b/resources/js/Components/TypeFilter.vue
@@ -6,17 +6,6 @@ defineProps<{ active: KnowledgeType | null }>()
 const emit = defineEmits<{ select: [type: KnowledgeType | null] }>()
 
 const types = Object.entries(KNOWLEDGE_TYPE_CONFIG) as [KnowledgeType, typeof KNOWLEDGE_TYPE_CONFIG[KnowledgeType]][]
-
-// Active-state class for each type button. Uses the saturated type colour
-// as the background with on-primary text, so the active pill inverts from
-// the default chip styling.
-const activeClass: Record<KnowledgeType, string> = {
-  cultural: 'bg-cultural text-on-primary',
-  governance: 'bg-governance text-on-primary',
-  land: 'bg-land text-on-primary',
-  relationship: 'bg-relationship text-on-primary',
-  event: 'bg-event text-on-primary',
-}
 </script>
 
 <template>
@@ -32,7 +21,7 @@ const activeClass: Record<KnowledgeType, string> = {
       v-for="[type, config] in types"
       :key="type"
       class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
-      :class="active === type ? activeClass[type] : config.chip"
+      :class="active === type ? config.activeChip : config.chip"
       @click="emit('select', type)"
     >
       {{ config.label }}

--- a/resources/js/Pages/Discovery/Ask.vue
+++ b/resources/js/Pages/Discovery/Ask.vue
@@ -17,7 +17,7 @@ defineProps<{
 
 <template>
   <DiscoveryLayout :community="community">
-    <div class="bg-gradient-to-br from-indigo to-indigo-mid text-white py-10 px-6 text-center">
+    <div class="bg-gradient-to-br from-primary to-primary-hover text-on-primary py-10 px-6 text-center">
       <div class="flex justify-center">
         <SearchInput :community-slug="community.slug" :initial-query="question" />
       </div>
@@ -32,7 +32,7 @@ defineProps<{
       />
 
       <div v-if="relatedItems.items.length > 0" class="mt-8">
-        <h2 class="text-lg font-semibold text-indigo-dark mb-4">Related knowledge</h2>
+        <h2 class="text-lg font-semibold text-ink mb-4">Related knowledge</h2>
         <div class="grid gap-4 sm:grid-cols-2">
           <KnowledgeCard
             v-for="item in relatedItems.items"

--- a/resources/js/Pages/Discovery/Index.vue
+++ b/resources/js/Pages/Discovery/Index.vue
@@ -21,9 +21,9 @@ const filteredItems = computed(() => {
 
 <template>
   <DiscoveryLayout :community="community">
-    <div class="bg-gradient-to-br from-indigo to-indigo-mid text-white py-16 px-6 text-center">
+    <div class="bg-gradient-to-br from-primary to-primary-hover text-on-primary py-16 px-6 text-center">
       <h1 class="text-3xl font-bold mb-2">{{ community.name }} Knowledge Base</h1>
-      <p class="text-indigo-light mb-8">Search or ask anything</p>
+      <p class="text-primary-subtle mb-8">Search or ask anything</p>
       <div class="flex justify-center">
         <SearchInput :community-slug="community.slug" />
       </div>
@@ -44,7 +44,7 @@ const filteredItems = computed(() => {
         />
       </div>
 
-      <p v-if="filteredItems.length === 0" class="text-muted text-center mt-12">
+      <p v-if="filteredItems.length === 0" class="text-ink-muted text-center mt-12">
         No knowledge items yet. Upload documents to get started.
       </p>
     </div>

--- a/resources/js/Pages/Discovery/Search.vue
+++ b/resources/js/Pages/Discovery/Search.vue
@@ -15,14 +15,14 @@ const props = defineProps<{
 
 <template>
   <DiscoveryLayout :community="community">
-    <div class="bg-gradient-to-br from-indigo to-indigo-mid text-white py-10 px-6 text-center">
+    <div class="bg-gradient-to-br from-primary to-primary-hover text-on-primary py-10 px-6 text-center">
       <div class="flex justify-center">
         <SearchInput :community-slug="community.slug" :initial-query="query" />
       </div>
     </div>
 
     <div class="max-w-5xl mx-auto px-6 py-8">
-      <p class="text-sm text-muted mb-4">{{ results.totalHits }} {{ results.totalHits === 1 ? 'result' : 'results' }} for "{{ query }}"</p>
+      <p class="text-sm text-ink-muted mb-4">{{ results.totalHits }} {{ results.totalHits === 1 ? 'result' : 'results' }} for "{{ query }}"</p>
 
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <KnowledgeCard

--- a/resources/js/Pages/Discovery/Show.vue
+++ b/resources/js/Pages/Discovery/Show.vue
@@ -15,7 +15,7 @@ const typeConfig = props.item.knowledgeType ? KNOWLEDGE_TYPE_CONFIG[props.item.k
 <template>
   <DiscoveryLayout :community="community">
     <div class="max-w-3xl mx-auto px-6 py-8">
-      <Link :href="`/${community.slug}`" class="text-sm text-indigo hover:underline mb-4 inline-block">
+      <Link :href="`/${community.slug}`" class="text-sm text-primary hover:underline mb-4 inline-block">
         ← Back to browse
       </Link>
 
@@ -24,16 +24,16 @@ const typeConfig = props.item.knowledgeType ? KNOWLEDGE_TYPE_CONFIG[props.item.k
           <span
             v-if="typeConfig"
             class="inline-block text-xs px-2 py-0.5 rounded-full"
-            :style="{ backgroundColor: typeConfig.bg, color: typeConfig.text }"
+            :class="typeConfig.chip"
           >
             {{ typeConfig.label }}
           </span>
-          <span class="text-xs text-muted">{{ item.createdAt }}</span>
+          <span class="text-xs text-ink-muted">{{ item.createdAt }}</span>
         </div>
 
-        <h1 class="text-2xl font-bold text-indigo-dark mb-6">{{ item.title }}</h1>
+        <h1 class="text-2xl font-bold text-ink mb-6">{{ item.title }}</h1>
 
-        <div class="prose prose-sm max-w-none text-indigo-dark" v-html="item.content" />
+        <div class="prose prose-sm max-w-none text-ink" v-html="item.content" />
       </article>
     </div>
   </DiscoveryLayout>

--- a/resources/js/Pages/Management/Dashboard.vue
+++ b/resources/js/Pages/Management/Dashboard.vue
@@ -7,7 +7,7 @@ defineProps<{ community: Community }>()
 
 <template>
   <ManagementLayout :community="community">
-    <h1 class="text-2xl font-bold text-indigo-dark mb-6">Dashboard</h1>
-    <p class="text-muted">Management dashboard coming soon. Use the sidebar to navigate.</p>
+    <h1 class="text-2xl font-bold text-ink mb-6">Dashboard</h1>
+    <p class="text-ink-muted">Management dashboard coming soon. Use the sidebar to navigate.</p>
   </ManagementLayout>
 </template>

--- a/resources/js/Pages/Management/Export.vue
+++ b/resources/js/Pages/Management/Export.vue
@@ -11,21 +11,21 @@ function requestExport() {
 
 <template>
   <ManagementLayout :community="community">
-    <h1 class="text-2xl font-bold text-indigo-dark mb-6">Export</h1>
+    <h1 class="text-2xl font-bold text-ink mb-6">Export</h1>
 
-    <div class="bg-white rounded-lg border border-border p-6 max-w-lg">
-      <h2 class="font-semibold text-indigo-dark mb-2">Export all community data</h2>
-      <p class="text-sm text-muted mb-4">
+    <div class="bg-surface-raised rounded-lg border border-border p-6 max-w-lg">
+      <h2 class="font-semibold text-ink mb-2">Export all community data</h2>
+      <p class="text-sm text-ink-muted mb-4">
         Downloads a ZIP archive containing all knowledge items (Markdown), original media files,
         embeddings, and community configuration. Open formats only, no vendor lock-in.
       </p>
-      <p class="text-xs text-indigo bg-indigo-light rounded p-3 mb-4">
+      <p class="text-xs text-primary bg-primary-subtle rounded p-3 mb-4">
         <strong>Community Sovereignty Guarantee:</strong> Your data is always exportable in open formats.
         You can move to any infrastructure at any time.
       </p>
       <button
         @click="requestExport"
-        class="px-6 py-2 bg-indigo text-white rounded-lg hover:bg-indigo-mid font-medium"
+        class="px-6 py-2 bg-primary text-on-primary rounded-lg hover:bg-primary-hover font-medium"
       >
         Export Community Data
       </button>

--- a/resources/js/Pages/Management/Reports.vue
+++ b/resources/js/Pages/Management/Reports.vue
@@ -21,7 +21,7 @@ function generateReport(type: string) {
 
 <template>
   <ManagementLayout :community="community">
-    <h1 class="text-2xl font-bold text-indigo-dark mb-6">Reports</h1>
+    <h1 class="text-2xl font-bold text-ink mb-6">Reports</h1>
 
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-8">
       <ReportCard

--- a/resources/js/Pages/Management/Users.vue
+++ b/resources/js/Pages/Management/Users.vue
@@ -7,7 +7,7 @@ defineProps<{ community: Community }>()
 
 <template>
   <ManagementLayout :community="community">
-    <h1 class="text-2xl font-bold text-indigo-dark mb-6">Users</h1>
-    <p class="text-muted">User management will be wired when the Waaseyaa user service is integrated.</p>
+    <h1 class="text-2xl font-bold text-ink mb-6">Users</h1>
+    <p class="text-ink-muted">User management will be wired when the Waaseyaa user service is integrated.</p>
   </ManagementLayout>
 </template>

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -4,15 +4,21 @@ import { createApp, h } from 'vue';
 import '../css/app.css';
 
 // Read the brand colour from the --color-primary token so the Inertia
-// progress bar stays in sync with the design system. The CSS import above
-// is processed before this line executes, so the computed style is
-// already populated.
-const progressColor =
-    getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim() ||
-    '#3d35c8';
+// progress bar stays in sync with the design system. Called at app
+// creation rather than module eval time — in production builds the CSS
+// is loaded via a linked stylesheet, and stylesheet parsing races with
+// JS execution. Calling inside createInertiaApp's argument gives the
+// browser a beat to finish the parse; the `|| '#3d35c8'` fallback
+// handles the race losing anyway, matching the token default.
+function readBrandColor(): string {
+    const value = getComputedStyle(document.documentElement)
+        .getPropertyValue('--color-primary')
+        .trim();
+    return value || '#3d35c8';
+}
 
 createInertiaApp({
-    progress: { color: progressColor },
+    progress: { color: readBrandColor() },
     resolve: (name: string) => {
         const pages = import.meta.glob<{ default: DefineComponent }>('./Pages/**/*.vue', { eager: true });
         const page = pages[`./Pages/${name}.vue`];

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -3,8 +3,16 @@ import type { DefineComponent } from 'vue';
 import { createApp, h } from 'vue';
 import '../css/app.css';
 
+// Read the brand colour from the --color-primary token so the Inertia
+// progress bar stays in sync with the design system. The CSS import above
+// is processed before this line executes, so the computed style is
+// already populated.
+const progressColor =
+    getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim() ||
+    '#3d35c8';
+
 createInertiaApp({
-    progress: { color: '#3d35c8' },
+    progress: { color: progressColor },
     resolve: (name: string) => {
         const pages = import.meta.glob<{ default: DefineComponent }>('./Pages/**/*.vue', { eager: true });
         const page = pages[`./Pages/${name}.vue`];

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -56,20 +56,24 @@ export interface QaResponse {
 
 /**
  * Per-type badge styling. Classes reference the --color-{type}* tokens
- * defined in resources/css/app.css. `chip` is the default non-active
- * pill (subtle background + saturated text); `dot` is the solid colour
- * used for the small indicator dot on cards.
+ * defined in resources/css/app.css.
+ *
+ * - `chip` — default non-active pill (subtle background + saturated text).
+ * - `activeChip` — inverted pill used when the type is selected (saturated
+ *   background + on-primary text). Consumed by TypeFilter.
+ * - `dot` — solid colour used for the small indicator dot on cards.
  */
 export interface KnowledgeTypeStyle {
   label: string
   chip: string
+  activeChip: string
   dot: string
 }
 
 export const KNOWLEDGE_TYPE_CONFIG: Record<KnowledgeType, KnowledgeTypeStyle> = {
-  cultural: { label: 'Cultural', chip: 'bg-cultural-subtle text-cultural', dot: 'bg-cultural' },
-  governance: { label: 'Governance', chip: 'bg-governance-subtle text-governance', dot: 'bg-governance' },
-  land: { label: 'Land', chip: 'bg-land-subtle text-land', dot: 'bg-land' },
-  relationship: { label: 'Relationship', chip: 'bg-relationship-subtle text-relationship', dot: 'bg-relationship' },
-  event: { label: 'Event', chip: 'bg-event-subtle text-event', dot: 'bg-event' },
+  cultural: { label: 'Cultural', chip: 'bg-cultural-subtle text-cultural', activeChip: 'bg-cultural text-on-primary', dot: 'bg-cultural' },
+  governance: { label: 'Governance', chip: 'bg-governance-subtle text-governance', activeChip: 'bg-governance text-on-primary', dot: 'bg-governance' },
+  land: { label: 'Land', chip: 'bg-land-subtle text-land', activeChip: 'bg-land text-on-primary', dot: 'bg-land' },
+  relationship: { label: 'Relationship', chip: 'bg-relationship-subtle text-relationship', activeChip: 'bg-relationship text-on-primary', dot: 'bg-relationship' },
+  event: { label: 'Event', chip: 'bg-event-subtle text-event', activeChip: 'bg-event text-on-primary', dot: 'bg-event' },
 }

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -54,10 +54,22 @@ export interface QaResponse {
   noRelevantItems: boolean
 }
 
-export const KNOWLEDGE_TYPE_CONFIG: Record<KnowledgeType, { label: string; bg: string; text: string }> = {
-  cultural: { label: 'Cultural', bg: '#f0f0ff', text: '#3d35c8' },
-  governance: { label: 'Governance', bg: '#e8f5f0', text: '#1e8a6e' },
-  land: { label: 'Land', bg: '#edf2e8', text: '#4a7a3a' },
-  relationship: { label: 'Relationship', bg: '#fff0f5', text: '#c83568' },
-  event: { label: 'Event', bg: '#fff8e8', text: '#c89a35' },
+/**
+ * Per-type badge styling. Classes reference the --color-{type}* tokens
+ * defined in resources/css/app.css. `chip` is the default non-active
+ * pill (subtle background + saturated text); `dot` is the solid colour
+ * used for the small indicator dot on cards.
+ */
+export interface KnowledgeTypeStyle {
+  label: string
+  chip: string
+  dot: string
+}
+
+export const KNOWLEDGE_TYPE_CONFIG: Record<KnowledgeType, KnowledgeTypeStyle> = {
+  cultural: { label: 'Cultural', chip: 'bg-cultural-subtle text-cultural', dot: 'bg-cultural' },
+  governance: { label: 'Governance', chip: 'bg-governance-subtle text-governance', dot: 'bg-governance' },
+  land: { label: 'Land', chip: 'bg-land-subtle text-land', dot: 'bg-land' },
+  relationship: { label: 'Relationship', chip: 'bg-relationship-subtle text-relationship', dot: 'bg-relationship' },
+  event: { label: 'Event', chip: 'bg-event-subtle text-event', dot: 'bg-event' },
 }


### PR DESCRIPTION
Replaces closed PR #85 (auto-closed when its stacked base branch was deleted by the squash-merge of #82). Closes #83.

## Summary

- Migrates the 13 remaining Vue files to the semantic token layer from #82.
- Hoists `KNOWLEDGE_TYPE_CONFIG` from `{ label, bg, text }` inline-hex to `{ label, chip, activeChip, dot }` class bindings.
- Pulls Inertia progress colour from `--color-primary` via a lazy `readBrandColor()` helper called from the `createInertiaApp` argument (avoids the stylesheet-parse race on production builds).
- Deletes legacy aliases: `--color-indigo`, `--color-indigo-dark`, `--color-indigo-light`, `--color-indigo-mid`, `--color-muted`, `--color-bg`.
- Adds polish-nit comments: ink/inverse shade coupling, on-inverse vs on-primary split, `--color-cultural` intentionally duplicates `--color-primary` hex (Tailwind v4 `@theme` can't reference other tokens).

## Verification

| Check | Result |
|---|---|
| `npx vue-tsc --noEmit` | clean |
| `npm run test:js` | 19/19 |
| `npm run build` | green (CSS 22.03 kB → gzip 4.94 kB) |
| `grep -rE 'indigo-\|text-muted\|bg-bg\b' resources/js` | zero matches |
| `grep -rE '#[0-9a-fA-F]{3,8}' resources/js` | only the Inertia fallback in `app.ts` |
| Puppeteer sha256 vs `main` (6 pages) | all IDENTICAL |

## Review follow-ups already applied

All three in-scope nits from the #85 review are on this branch:

- `activeChip` folded into `KnowledgeTypeStyle` (no more asymmetric Record in `TypeFilter`).
- `readBrandColor()` defers `getComputedStyle` to `createInertiaApp` argument eval rather than module eval time.
- `--color-cultural` comment documents the intentional hex duplication.

## Backlog issue filed

#86 — add a Vitest assertion that `KNOWLEDGE_TYPE_CONFIG` covers all `KnowledgeType` members. Not in scope for this PR.

Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)