### PR TITLE
refactor(#88): standardize on App\ namespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Giiken is a sovereign indigenous knowledge management platform built on the **Waaseyaa** custom PHP framework. It implements community-based RBAC for multi-tenant knowledge governance.
 
-**PHP:** 8.4+ | **License:** GPL-2.0-or-later | **Namespace:** `Giiken\` (PSR-4)
+**PHP:** 8.4+ | **License:** GPL-2.0-or-later | **Namespace:** `App\` (PSR-4)
 
 ## Boot-to-browser status (as of 2026-04-11)
 
@@ -28,7 +28,7 @@ PHPUnit: 198/198 passing.
 
 - waaseyaa/framework#1125 — cli bin entrypoint, `app.url` default, array-controller normalization (alpha.107).
 - waaseyaa/framework#1127 — foundation→ssr dependency.
-- giiken#42 — `GiikenServiceProvider` provider registrations.
+- giiken#42 — `AppServiceProvider` provider registrations.
 - giiken#43 — entity schema migrations (`community`, `knowledge_item`, `wiki_lint_report`).
 - giiken#44 — `giiken:seed:test-community` console command.
 
@@ -92,7 +92,7 @@ Waaseyaa is a modular PHP framework split into 30+ packages (`waaseyaa/*`). Key 
 
 All domain objects extend `ContentEntityBase`. Properties are accessed via `$this->get('key')` (with `$casts` for enums, datetimes, and JSON lists) — define typed getter methods on top of that. Construct app/test instances with `EntityClass::make([...])` (or the domain constructor for `Community`); use `fromStorage()` when simulating `EntityInstantiator` / SQL hydration. Repositories wrap `EntityRepositoryInterface` with typed query methods and set `updated_at` (ISO-8601) on save.
 
-Three entity types are registered in `GiikenServiceProvider`:
+Three entity types are registered in `AppServiceProvider`:
 - `community` → `Entity\Community\Community` (multi-tenant container, owns a `WikiSchema`)
 - `knowledge_item` → `Entity\KnowledgeItem\KnowledgeItem` (primary domain object, implements `HasCommunity`)
 - `wiki_lint_report` → `Wiki\WikiLintReport` (stores lint findings per community)
@@ -138,13 +138,13 @@ Built-in checks: `BrokenLinkCheck`, `OrphanPageCheck`.
 
 ### Service Provider
 
-`GiikenServiceProvider` registers entity types with `EntityTypeManager` and defines routes via `WaaseyaaRouter`. This is the entry point for adding new entity types or wiring new ingestion handlers.
+`AppServiceProvider` registers entity types with `EntityTypeManager` and defines routes via `WaaseyaaRouter`. This is the entry point for adding new entity types or wiring new ingestion handlers.
 
 ### Lifecycle Documentation Governance
 
 - Canonical runtime flow doc: `docs/architecture/lifecycle.md`
 - CI enforces drift checks via `scripts/check-lifecycle-drift.sh`
-- If lifecycle-impacting files change (`public/index.php`, `src/GiikenServiceProvider.php`, HTTP controllers/middleware, entities/query/pipeline code), update `docs/architecture/lifecycle.md` in the same PR.
+- If lifecycle-impacting files change (`public/index.php`, `src/Provider/AppServiceProvider.php`, HTTP controllers/middleware, entities/query/pipeline code), update `docs/architecture/lifecycle.md` in the same PR.
 
 ## Testing Conventions
 

--- a/composer.json
+++ b/composer.json
@@ -44,12 +44,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Giiken\\": "src/"
+            "App\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Giiken\\Tests\\": "tests/"
+            "App\\Tests\\": "tests/"
         }
     },
     "config": {
@@ -80,7 +80,7 @@
         },
         "waaseyaa": {
             "providers": [
-                "Giiken\\GiikenServiceProvider"
+                "App\\Provider\\AppServiceProvider"
             ]
         }
     },

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -7,7 +7,7 @@ This document describes how a request moves through Giiken at runtime, where app
 - App: `giiken`
 - Framework: `waaseyaa/*`
 - Entrypoint: `public/index.php`
-- Primary app integration point: `src/GiikenServiceProvider.php`
+- Primary app integration point: `src/AppServiceProvider.php`
 
 ## 1. Boot Lifecycle
 
@@ -42,10 +42,10 @@ Inside `HttpKernel::handle()` -> `AbstractKernel::boot()`:
 
 ### 1.3 Where Giiken Enters
 
-The first Giiken app-level class in normal boot is `Giiken\GiikenServiceProvider`:
+The first Giiken app-level class in normal boot is `App\AppServiceProvider`:
 
 - `register()` contributes app entity types (`community`, `knowledge_item`, `wiki_lint_report`)
-- `register()` binds app services resolved by SSR `serviceResolver`: `CommunityRepositoryInterface`, `KnowledgeItemRepositoryInterface`, `SearchService`, `QaServiceInterface`, `ReportServiceInterface`, `ExportServiceInterface`, `SynthesisService`, dev `NullEmbeddingProvider` / `NullLlmProvider`, and a PSR-14 `EventDispatcherInterface` alias to the kernel dispatcher (for `EntityRepository` construction); registers `Giiken\Http\Inertia\InertiaHttpResponder` (full-page renderer from DI when present)
+- `register()` binds app services resolved by SSR `serviceResolver`: `CommunityRepositoryInterface`, `KnowledgeItemRepositoryInterface`, `SearchService`, `QaServiceInterface`, `ReportServiceInterface`, `ExportServiceInterface`, `SynthesisService`, dev `NullEmbeddingProvider` / `NullLlmProvider`, and a PSR-14 `EventDispatcherInterface` alias to the kernel dispatcher (for `EntityRepository` construction); registers `App\Http\Inertia\InertiaHttpResponder` (full-page renderer from DI when present)
 - `register()` re-binds `InertiaFullPageRendererInterface` with a project-root-based `ViteAssetManager` (`public/build` manifest or `VITE_DEV_SERVER`), sets `Inertia::setVersion('giiken')`, and refreshes `Inertia::setRenderer(...)` with a custom template closure that rewrites the data-page attribute from `data-page="true"` to `data-page="app"` so Inertia v2's client-side reader (`script[data-page="app"]`) actually finds the initial page object — workaround for waaseyaa/framework#1227
 - Frontend bundle: Vite entry `resources/js/app.ts`, production output under `public/build` (`npm run build`); set `VITE_DEV_SERVER` (e.g. `http://127.0.0.1:5173`) when using `npm run dev` for HMR
 - `commands()` contributes CLI commands (`giiken:seed:test-community`)
@@ -79,7 +79,7 @@ After boot, `HttpKernel::serveHttpRequest()` executes:
 
 ### 2.2 App Route Registration
 
-App routes are added through `GiikenServiceProvider::routes(...)`, including:
+App routes are added through `AppServiceProvider::routes(...)`, including:
 
 - Public landing (Inertia): `GET` `/` → `Discover` page (`HomeController::discover`)
 - Session HTML auth (public): `GET`/`POST` `/login`, `GET` `/logout`
@@ -122,7 +122,7 @@ Controllers should guard optional services explicitly and return `bootError` pro
 
 ### 3.1 Entity Registration
 
-Entity types are declared in `GiikenServiceProvider::register()` and attached to `EntityTypeManager`.
+Entity types are declared in `AppServiceProvider::register()` and attached to `EntityTypeManager`.
 
 ### 3.2 Repository Access
 
@@ -163,7 +163,7 @@ Giiken requires **`waaseyaa/*` ^0.1.0-alpha.120** and `nesbot/carbon` so datetim
 
 ### 3.2.6 Integration tests
 
-- `tests/Integration/` boots `HttpKernel` with `WAASEYAA_DB=:memory:`, runs app migrations, and asserts real repository hydration, casts, and round-trips (`ContentEntitySqlIntegrationTest`, `GiikenKernelIntegrationTestCase`). Composer **`autoload-dev`** maps `Giiken\Tests\` → `tests/` for PHPUnit.
+- `tests/Integration/` boots `HttpKernel` with `WAASEYAA_DB=:memory:`, runs app migrations, and asserts real repository hydration, casts, and round-trips (`ContentEntitySqlIntegrationTest`, `GiikenKernelIntegrationTestCase`). Composer **`autoload-dev`** maps `App\Tests\` → `tests/` for PHPUnit.
 - `ContentEntitySqlIntegrationTest` also covers `EntityInstantiator` re-hydration for all three entity types, SSR-style `<time datetime="">` formatting from ISO timestamps, `set('updated_at')` → ISO-8601 in `toArray()`, raw-SQL corrupt `wiki_lint_report.findings` normalization on load, and `toArray()` normalization after repository round-trips (enums, timestamps, JSON list columns).
 
 ### 3.3 Query + Pipeline Flow
@@ -174,7 +174,7 @@ Giiken requires **`waaseyaa/*` ^0.1.0-alpha.120** and `nesbot/carbon` so datetim
 - `DiscoveryController::search` pulls the user-facing search term from the `q` query-string parameter (matching the `SearchInput.vue` submit contract and `Pagination.vue` page links), constructs a `SearchQuery(query, communityId, page)`, calls `SearchService::search`, and ships `query` + `results` as Inertia props for `Pages/Discovery/Search.vue`. Empty `q` intentionally falls through to `SearchService::recentItems` so the page renders the full community feed.
 - `SearchService::hybridSearch` tokenizes multi-word queries before hitting FTS to work around `Waaseyaa\Search\Fts5SearchProvider::escapeQuery`, which quotes each term and hands them to FTS5 MATCH as an implicit AND. The tokenizer is locale-aware (see waaseyaa/giiken#67): it always drops empty tokens, but the English stopword list is applied only when `SearchQuery::$locale` is null or `'en'`. Non-English locales keep every non-empty token so Indigenous-language queries are not silently eroded. The length floor is 1, not 2, since FTS5 handles single-character tokens and short stem words are meaningful across several Indigenous languages. After tokenization the service issues one FTS `SearchRequest` per surviving term and merges the per-term hits by keeping each doc's best raw score, then adds a linear "matched-more-terms-wins" bonus (`SearchService::MULTI_TERM_MATCH_BONUS * (distinct_terms_matched - 1)`) before min-max normalization so documents hit by more of the query outrank documents hit by fewer with a comparable per-term score (see waaseyaa/giiken#68). Queries that tokenize to zero terms (pure stopwords under an English locale) fall back to a single-shot pass of the original string so the vendor escaper sees exactly what it would have seen pre-tokenization. `DiscoveryController::search` and `::ask` both pass `$community->locale()` into the `SearchQuery` so the tokenizer knows which path to take. The shared prelude (build `InboundHttpRequest`, pull `communitySlug` + `q`, look up the community) lives in the private `DiscoveryController::resolveCommunityContext` helper so both methods lead with a single line (waaseyaa/giiken#71, behavior-neutral).
 - `DiscoveryController::ask` reads the user's question from the same `q` query-string parameter (`SearchInput.vue` routes long or `?`-ending input to `/{slug}/ask` with key `q`), hands it to `QaServiceInterface::ask`, then calls `SearchService::search` with the question as the search term to build a related-items sidebar. The controller ships `question` (the original `q` value), `answer`, `citations` (each with `itemId`, `title`, `excerpt`, `knowledgeType`), `noRelevantItems`, and `relatedItems` as Inertia props for `Pages/Discovery/Ask.vue`. Ask.vue hands `answer` + `citations` + `noRelevantItems` to `Components/AnswerPanel.vue`, which parses `[N]` markers into anchored `<sup>` elements pointing at matching `#citation-N` cards rendered by `Components/CitationCard.vue`. When both `answer` is empty and `citations` is empty, or when `noRelevantItems` is true, `Components/NoAnswerState.vue` is rendered instead. Related items still render below via the existing `KnowledgeCard`.
-- `ManagementController::ingestUpload` (`POST /{communitySlug}/manage/ingestion`) handles multipart file uploads from `Pages/Management/Ingestion.vue`. The controller reads `$httpRequest->files->get('file')` as a Symfony `UploadedFile`, then calls `IngestionHandlerRegistry::handle()` with the file's pathname, MIME type, original filename, and the resolved community. The registry dispatches to the first registered handler whose `supports($mime)` returns true. Five handlers are wired in `GiikenServiceProvider::registerIngestionHandlers`: `MarkdownIngestionHandler`, `CsvIngestionHandler`, `HtmlIngestionHandler`, `DocumentIngestionHandler`, and `MediaIngestionHandler`. All five depend on a single `FileRepositoryInterface` binding (`Waaseyaa\Media\LocalFileRepository` rooted at `storage/media/`); the CSV/HTML/Document handlers also depend on `FileConverterInterface` (`MarkItDownConverter` wrapping `storage/markitdown-venv/bin/markitdown`); the Media handler additionally depends on `QueueInterface` (`Waaseyaa\Queue\SyncQueue`) so audio/video uploads enqueue a no-op `TranscribeJob` placeholder. On success the controller ships a `uploadResult` Inertia prop (original filename, MIME, media id, metadata); on failure (missing file, no matching handler, handler-level `IngestionException`) it ships `uploadError` instead. See waaseyaa/giiken#39.
+- `ManagementController::ingestUpload` (`POST /{communitySlug}/manage/ingestion`) handles multipart file uploads from `Pages/Management/Ingestion.vue`. The controller reads `$httpRequest->files->get('file')` as a Symfony `UploadedFile`, then calls `IngestionHandlerRegistry::handle()` with the file's pathname, MIME type, original filename, and the resolved community. The registry dispatches to the first registered handler whose `supports($mime)` returns true. Five handlers are wired in `AppServiceProvider::registerIngestionHandlers`: `MarkdownIngestionHandler`, `CsvIngestionHandler`, `HtmlIngestionHandler`, `DocumentIngestionHandler`, and `MediaIngestionHandler`. All five depend on a single `FileRepositoryInterface` binding (`Waaseyaa\Media\LocalFileRepository` rooted at `storage/media/`); the CSV/HTML/Document handlers also depend on `FileConverterInterface` (`MarkItDownConverter` wrapping `storage/markitdown-venv/bin/markitdown`); the Media handler additionally depends on `QueueInterface` (`Waaseyaa\Queue\SyncQueue`) so audio/video uploads enqueue a no-op `TranscribeJob` placeholder. On success the controller ships a `uploadResult` Inertia prop (original filename, MIME, media id, metadata); on failure (missing file, no matching handler, handler-level `IngestionException`) it ships `uploadError` instead. See waaseyaa/giiken#39.
 - `KnowledgeItemRepository::save` works around two framework quirks to keep FTS in sync: (1) after `Waaseyaa\EntityRepository::save` dispatches `POST_SAVE`, `SearchIndexSubscriber` indexes the entity while it still has a null auto-increment id, producing a stale `document_id` of `knowledge_item:`; and (2) `SearchService::hybridSearch` needs the real integer id to look items up. The repository reloads the new entity by uuid, calls `Fts5SearchIndexer::remove('knowledge_item:')` to scrub the stale empty-id row, then re-indexes the reloaded copy. `SearchService::hybridSearch` also casts the `array_keys($scores)` id back to string before calling `$this->repository->find()`, since PHP coerces numeric-string array keys to int. The `remove('knowledge_item:')` scrub assumes a single writer — in a concurrent setup worker A could scrub the empty-suffix row worker B just wrote before B re-indexes. Giiken is single-process SQLite today so this is latent, and the whole workaround goes away when the framework back-fills auto-increment ids (waaseyaa/giiken#57, tracking comment at waaseyaa/giiken#72).
 
 ## 4. Failure Lifecycle
@@ -198,7 +198,7 @@ Giiken requires **`waaseyaa/*` ^0.1.0-alpha.120** and `nesbot/carbon` so datetim
 
 Primary extension points for app work:
 
-- `src/GiikenServiceProvider.php`
+- `src/AppServiceProvider.php`
   - service registration
   - entity type registration
   - route registration
@@ -214,7 +214,7 @@ Keep these true during refactoring:
 1. `public/index.php` always sends the response (`$response->send()`).
 2. Controllers keep the active SSR dispatch signature (`array $params`, `array $query`, `AccountInterface`, `HttpRequest`) and return `Response`.
 3. Optional service dependencies are handled with explicit guard returns (no implicit null behavior).
-4. `GiikenServiceProvider` remains the single source of app route/entity registration.
+4. `AppServiceProvider` remains the single source of app route/entity registration.
 5. Boot-time failures remain deterministic and observable (log + stable error response path).
 
 ## 7. Refactor Impact Matrix
@@ -222,7 +222,7 @@ Keep these true during refactoring:
 | Area | Likely Impact | Verify With |
 |---|---|---|
 | `public/index.php` | global boot and response emission | smoke test `/`, non-zero body |
-| `src/GiikenServiceProvider.php` | routes, entity types, DI bindings, CLI commands | route smoke tests + boot + `waaseyaa list` / migrate + seed |
+| `src/AppServiceProvider.php` | routes, entity types, DI bindings, CLI commands | route smoke tests + boot + `waaseyaa list` / migrate + seed |
 | `migrations/*.php` | SQLite schema for app entities | `bin/waaseyaa migrate` + repository integration |
 | `src/Http/Controller/*` | SSR dispatch and Inertia props | unit tests + route smoke tests |
 | `src/Entity/*` and repositories | data shape, persistence behavior | unit tests + integration tests |

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -15,10 +15,11 @@ This document describes how a request moves through Giiken at runtime, where app
 
 `public/index.php`:
 
-1. Loads Composer autoloader.
-2. Loads `.env` with `Symfony Dotenv` (fails fast with HTTP 500 on parse/path error).
-3. Instantiates `Waaseyaa\Foundation\Kernel\HttpKernel` with project root.
-4. Calls `$kernel->handle()` and then `$response->send()`.
+1. **CLI-server static file guard:** When running under PHP's built-in server (`PHP_SAPI === 'cli-server'`), checks if the request maps to an existing file on disk and returns `false` to let the server serve it directly. No effect on production servers.
+2. Loads Composer autoloader.
+3. Loads `.env` with `Symfony Dotenv` (fails fast with HTTP 500 on parse/path error).
+4. Instantiates `Waaseyaa\Foundation\Kernel\HttpKernel` with project root.
+5. Calls `$kernel->handle()` and then `$response->send()`.
 
 ### 1.2 Kernel Boot Sequence
 

--- a/docs/superpowers/plans/2026-04-04-ingestion-pipeline.md
+++ b/docs/superpowers/plans/2026-04-04-ingestion-pipeline.md
@@ -67,7 +67,7 @@
 | File | Changes |
 |---|---|
 | `src/Entity/KnowledgeItem/KnowledgeItem.php` | Add `toMarkdown()` method |
-| `src/GiikenServiceProvider.php` | Register IngestionHandlerRegistry, handlers, CompilationPipeline |
+| `src/AppServiceProvider.php` | Register IngestionHandlerRegistry, handlers, CompilationPipeline |
 | `tests/Unit/Entity/KnowledgeItem/KnowledgeItemTest.php` | Add toMarkdown tests (or separate test file) |
 
 ---
@@ -77,7 +77,7 @@
 **Files:**
 - Create: `src/Access/PublicIngestionPolicy.php`
 - Create: `tests/Unit/Access/PublicIngestionPolicyTest.php`
-- Modify: `src/GiikenServiceProvider.php`
+- Modify: `src/AppServiceProvider.php`
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -88,10 +88,10 @@ Create `tests/Unit/Access/PublicIngestionPolicyTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Access;
+namespace App\Tests\Unit\Access;
 
-use Giiken\Access\PublicIngestionPolicy;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Access\PublicIngestionPolicy;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -231,9 +231,9 @@ Create `src/Access/PublicIngestionPolicy.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Access;
+namespace App\Access;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 use Waaseyaa\Access\AccessPolicyInterface;
 use Waaseyaa\Access\AccessResult;
 use Waaseyaa\Access\AccountInterface;
@@ -323,9 +323,9 @@ Create `tests/Unit/Entity/KnowledgeItem/KnowledgeItemToMarkdownTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Entity\KnowledgeItem;
+namespace App\Tests\Unit\Entity\KnowledgeItem;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -490,7 +490,7 @@ Create `src/Ingestion/RawDocument.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion;
+namespace App\Ingestion;
 
 /**
  * Immutable value object returned by ingestion handlers.
@@ -524,7 +524,7 @@ Create `src/Ingestion/IngestionException.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion;
+namespace App\Ingestion;
 
 final class IngestionException extends \RuntimeException {}
 ```
@@ -536,9 +536,9 @@ Create `src/Ingestion/FileIngestionHandlerInterface.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion;
+namespace App\Ingestion;
 
-use Giiken\Entity\Community\Community;
+use App\Entity\Community\Community;
 
 interface FileIngestionHandlerInterface
 {
@@ -573,13 +573,13 @@ Create `tests/Unit/Ingestion/IngestionHandlerRegistryTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion;
+namespace App\Tests\Unit\Ingestion;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\IngestionHandlerRegistry;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\IngestionHandlerRegistry;
+use App\Ingestion\RawDocument;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -694,9 +694,9 @@ Create `src/Ingestion/IngestionHandlerRegistry.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion;
+namespace App\Ingestion;
 
-use Giiken\Entity\Community\Community;
+use App\Entity\Community\Community;
 
 final class IngestionHandlerRegistry
 {
@@ -757,7 +757,7 @@ Create `src/Ingestion/Converter/ConversionException.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Converter;
+namespace App\Ingestion\Converter;
 
 final class ConversionException extends \RuntimeException {}
 ```
@@ -769,7 +769,7 @@ Create `src/Ingestion/Converter/FileConverterInterface.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Converter;
+namespace App\Ingestion\Converter;
 
 interface FileConverterInterface
 {
@@ -793,10 +793,10 @@ Create `tests/Unit/Ingestion/Converter/MarkItDownConverterTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Converter;
+namespace App\Tests\Unit\Ingestion\Converter;
 
-use Giiken\Ingestion\Converter\ConversionException;
-use Giiken\Ingestion\Converter\MarkItDownConverter;
+use App\Ingestion\Converter\ConversionException;
+use App\Ingestion\Converter\MarkItDownConverter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -889,7 +889,7 @@ Create `src/Ingestion/Converter/MarkItDownConverter.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Converter;
+namespace App\Ingestion\Converter;
 
 final class MarkItDownConverter implements FileConverterInterface
 {
@@ -1022,10 +1022,10 @@ Create `tests/Unit/Ingestion/Handler/MarkdownIngestionHandlerTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Handler;
+namespace App\Tests\Unit\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Handler\MarkdownIngestionHandler;
+use App\Entity\Community\Community;
+use App\Ingestion\Handler\MarkdownIngestionHandler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1163,12 +1163,12 @@ Create `src/Ingestion/Handler/MarkdownIngestionHandler.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Handler;
+namespace App\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\RawDocument;
 use Waaseyaa\Media\FileRepositoryInterface;
 
 final class MarkdownIngestionHandler implements FileIngestionHandlerInterface
@@ -1276,11 +1276,11 @@ Create `tests/Unit/Ingestion/Handler/DocumentIngestionHandlerTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Handler;
+namespace App\Tests\Unit\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\Handler\DocumentIngestionHandler;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\Handler\DocumentIngestionHandler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1362,13 +1362,13 @@ Create `src/Ingestion/Handler/DocumentIngestionHandler.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Handler;
+namespace App\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\RawDocument;
 use Waaseyaa\Media\FileRepositoryInterface;
 
 final class DocumentIngestionHandler implements FileIngestionHandlerInterface
@@ -1439,11 +1439,11 @@ Create `tests/Unit/Ingestion/Handler/CsvIngestionHandlerTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Handler;
+namespace App\Tests\Unit\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\Handler\CsvIngestionHandler;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\Handler\CsvIngestionHandler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1510,13 +1510,13 @@ Create `src/Ingestion/Handler/CsvIngestionHandler.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Handler;
+namespace App\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\RawDocument;
 use Waaseyaa\Media\FileRepositoryInterface;
 
 final class CsvIngestionHandler implements FileIngestionHandlerInterface
@@ -1613,11 +1613,11 @@ Create `tests/Unit/Ingestion/Handler/HtmlIngestionHandlerTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Handler;
+namespace App\Tests\Unit\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\Handler\HtmlIngestionHandler;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\Handler\HtmlIngestionHandler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1682,13 +1682,13 @@ Create `src/Ingestion/Handler/HtmlIngestionHandler.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Handler;
+namespace App\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\RawDocument;
 use Waaseyaa\Media\FileRepositoryInterface;
 
 final class HtmlIngestionHandler implements FileIngestionHandlerInterface
@@ -1768,9 +1768,9 @@ Create `src/Pipeline/CompilationPayload.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline;
+namespace App\Pipeline;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Entity\KnowledgeItem\KnowledgeType;
 
 final class CompilationPayload
 {
@@ -1803,7 +1803,7 @@ Create `src/Pipeline/PipelineException.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline;
+namespace App\Pipeline;
 
 final class PipelineException extends \RuntimeException
 {
@@ -1825,7 +1825,7 @@ Create `src/Pipeline/SovereigntyConfig.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline;
+namespace App\Pipeline;
 
 final class SovereigntyConfig
 {
@@ -1850,7 +1850,7 @@ Create `src/Pipeline/Provider/LlmProviderInterface.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Provider;
+namespace App\Pipeline\Provider;
 
 interface LlmProviderInterface
 {
@@ -1872,7 +1872,7 @@ Create `src/Pipeline/Provider/EmbeddingProviderInterface.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Provider;
+namespace App\Pipeline\Provider;
 
 interface EmbeddingProviderInterface
 {
@@ -1915,10 +1915,10 @@ Create `tests/Unit/Pipeline/Step/TranscribeStepTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Pipeline\Step;
+namespace App\Tests\Unit\Pipeline\Step;
 
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\Step\TranscribeStep;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\Step\TranscribeStep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1961,9 +1961,9 @@ Create `src/Pipeline/Step/TranscribeStep.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Step;
+namespace App\Pipeline\Step;
 
-use Giiken\Pipeline\CompilationPayload;
+use App\Pipeline\CompilationPayload;
 use Waaseyaa\AiPipeline\PipelineContext;
 use Waaseyaa\AiPipeline\PipelineStepInterface;
 use Waaseyaa\AiPipeline\StepResult;
@@ -2015,13 +2015,13 @@ Create `tests/Unit/Pipeline/Step/ClassifyStepTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Pipeline\Step;
+namespace App\Tests\Unit\Pipeline\Step;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\PipelineException;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
-use Giiken\Pipeline\Step\ClassifyStep;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\PipelineException;
+use App\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\Step\ClassifyStep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -2109,12 +2109,12 @@ Create `src/Pipeline/Step/ClassifyStep.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Step;
+namespace App\Pipeline\Step;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\PipelineException;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\PipelineException;
+use App\Pipeline\Provider\LlmProviderInterface;
 use Waaseyaa\AiPipeline\PipelineContext;
 use Waaseyaa\AiPipeline\PipelineStepInterface;
 use Waaseyaa\AiPipeline\StepResult;
@@ -2195,13 +2195,13 @@ Create `tests/Unit/Pipeline/Step/StructureStepTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Pipeline\Step;
+namespace App\Tests\Unit\Pipeline\Step;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\PipelineException;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
-use Giiken\Pipeline\Step\StructureStep;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\PipelineException;
+use App\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\Step\StructureStep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -2281,11 +2281,11 @@ Create `src/Pipeline/Step/StructureStep.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Step;
+namespace App\Pipeline\Step;
 
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\PipelineException;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\PipelineException;
+use App\Pipeline\Provider\LlmProviderInterface;
 use Waaseyaa\AiPipeline\PipelineContext;
 use Waaseyaa\AiPipeline\PipelineStepInterface;
 use Waaseyaa\AiPipeline\StepResult;
@@ -2374,11 +2374,11 @@ Create `tests/Unit/Pipeline/Step/LinkStepTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Pipeline\Step;
+namespace App\Tests\Unit\Pipeline\Step;
 
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Pipeline\Step\LinkStep;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Step\LinkStep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -2479,10 +2479,10 @@ Create `src/Pipeline/Step/LinkStep.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Step;
+namespace App\Pipeline\Step;
 
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
 use Waaseyaa\AiPipeline\PipelineContext;
 use Waaseyaa\AiPipeline\PipelineStepInterface;
 use Waaseyaa\AiPipeline\StepResult;
@@ -2561,12 +2561,12 @@ Create `tests/Unit/Pipeline/Step/EmbedStepTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Pipeline\Step;
+namespace App\Tests\Unit\Pipeline\Step;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Pipeline\Step\EmbedStep;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Step\EmbedStep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -2664,11 +2664,11 @@ Create `src/Pipeline/Step/EmbedStep.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Step;
+namespace App\Pipeline\Step;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
 use Waaseyaa\AiPipeline\PipelineContext;
 use Waaseyaa\AiPipeline\PipelineStepInterface;
 use Waaseyaa\AiPipeline\StepResult;
@@ -2736,14 +2736,14 @@ Create `tests/Unit/Pipeline/CompilationPipelineTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Pipeline;
+namespace App\Tests\Unit\Pipeline;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Ingestion\RawDocument;
-use Giiken\Pipeline\CompilationPipeline;
-use Giiken\Pipeline\PipelineException;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Ingestion\RawDocument;
+use App\Pipeline\CompilationPipeline;
+use App\Pipeline\PipelineException;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Provider\LlmProviderInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -2857,16 +2857,16 @@ Create `src/Pipeline/CompilationPipeline.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline;
+namespace App\Pipeline;
 
-use Giiken\Ingestion\RawDocument;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
-use Giiken\Pipeline\Step\ClassifyStep;
-use Giiken\Pipeline\Step\EmbedStep;
-use Giiken\Pipeline\Step\LinkStep;
-use Giiken\Pipeline\Step\StructureStep;
-use Giiken\Pipeline\Step\TranscribeStep;
+use App\Ingestion\RawDocument;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\Step\ClassifyStep;
+use App\Pipeline\Step\EmbedStep;
+use App\Pipeline\Step\LinkStep;
+use App\Pipeline\Step\StructureStep;
+use App\Pipeline\Step\TranscribeStep;
 use Waaseyaa\AiPipeline\PipelineContext;
 use Waaseyaa\AiPipeline\PipelineStepInterface;
 use Waaseyaa\Entity\EntityRepositoryInterface;
@@ -2934,14 +2934,14 @@ git commit -m "feat: CompilationPipeline — full 5-step orchestrator (#8)"
 
 ---
 
-## Task 7: Register Everything in GiikenServiceProvider
+## Task 7: Register Everything in AppServiceProvider
 
 **Files:**
-- Modify: `src/GiikenServiceProvider.php`
+- Modify: `src/AppServiceProvider.php`
 
-- [ ] **Step 1: Update GiikenServiceProvider**
+- [ ] **Step 1: Update AppServiceProvider**
 
-Add handler and pipeline registration to `src/GiikenServiceProvider.php`:
+Add handler and pipeline registration to `src/AppServiceProvider.php`:
 
 ```php
 <?php
@@ -2950,20 +2950,20 @@ declare(strict_types=1);
 
 namespace Giiken;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Ingestion\Converter\MarkItDownConverter;
-use Giiken\Ingestion\Handler\CsvIngestionHandler;
-use Giiken\Ingestion\Handler\DocumentIngestionHandler;
-use Giiken\Ingestion\Handler\HtmlIngestionHandler;
-use Giiken\Ingestion\Handler\MarkdownIngestionHandler;
-use Giiken\Ingestion\IngestionHandlerRegistry;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Ingestion\Converter\MarkItDownConverter;
+use App\Ingestion\Handler\CsvIngestionHandler;
+use App\Ingestion\Handler\DocumentIngestionHandler;
+use App\Ingestion\Handler\HtmlIngestionHandler;
+use App\Ingestion\Handler\MarkdownIngestionHandler;
+use App\Ingestion\IngestionHandlerRegistry;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Routing\WaaseyaaRouter;
 
-final class GiikenServiceProvider extends ServiceProvider
+final class AppServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
@@ -3014,8 +3014,8 @@ Expected: All tests PASS.
 - [ ] **Step 3: Commit**
 
 ```bash
-git add src/GiikenServiceProvider.php
-git commit -m "feat: register ingestion handlers in GiikenServiceProvider (#5, #6)"
+git add src/AppServiceProvider.php
+git commit -m "feat: register ingestion handlers in AppServiceProvider (#5, #6)"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-04-05-giiken-boot-to-browser.md
+++ b/docs/superpowers/plans/2026-04-05-giiken-boot-to-browser.md
@@ -967,7 +967,7 @@ Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Migration;
+namespace App\Tests\Unit\Migration;
 
 use Doctrine\DBAL\DriverManager;
 use PHPUnit\Framework\Attributes\Test;
@@ -1045,9 +1045,9 @@ Expected: FAIL — migration file does not exist.
 declare(strict_types=1);
 
 use Doctrine\DBAL\Connection;
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Wiki\WikiLintReport;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Wiki\WikiLintReport;
 use Waaseyaa\Database\DBALDatabase;
 use Waaseyaa\Entity\EntityType;
 use Waaseyaa\EntityStorage\EntitySchemaSync;
@@ -1170,10 +1170,10 @@ Expected: a single `embed(string $text): array` method (confirmed during spec re
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Pipeline\Provider\Adapter;
+namespace App\Tests\Unit\Pipeline\Provider\Adapter;
 
-use Giiken\Pipeline\Provider\Adapter\FakeEmbeddingAdapter;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Provider\Adapter\FakeEmbeddingAdapter;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1237,15 +1237,15 @@ Expected: FAIL — adapter class does not exist.
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Provider\Adapter;
+namespace App\Pipeline\Provider\Adapter;
 
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
 use Waaseyaa\AI\Vector\Testing\FakeEmbeddingProvider;
 
 /**
  * Bridges the framework's FakeEmbeddingProvider to Giiken's local
  * EmbeddingProviderInterface. Used as the dev/default binding in
- * GiikenServiceProvider until a real provider is wired.
+ * AppServiceProvider until a real provider is wired.
  *
  * See waaseyaa/giiken#40 for the plan to replace this with a
  * sovereignty-profile-aware real provider.
@@ -1307,10 +1307,10 @@ Expected: a `complete(string $systemPrompt, string $userContent): string` method
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Pipeline\Provider\Adapter;
+namespace App\Tests\Unit\Pipeline\Provider\Adapter;
 
-use Giiken\Pipeline\Provider\Adapter\NullLlmAdapter;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\Provider\Adapter\NullLlmAdapter;
+use App\Pipeline\Provider\LlmProviderInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1363,9 +1363,9 @@ The framework's `NullLlmProvider` implements the multi-turn `ProviderInterface` 
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Provider\Adapter;
+namespace App\Pipeline\Provider\Adapter;
 
-use Giiken\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\Provider\LlmProviderInterface;
 use Waaseyaa\AiAgent\Provider\MessageRequest;
 use Waaseyaa\AiAgent\Provider\NullLlmProvider;
 
@@ -1452,13 +1452,13 @@ cat src/Access/AccessTier.php
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Console;
+namespace App\Tests\Unit\Console;
 
-use Giiken\Console\SeedTestCommunityCommand;
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Console\SeedTestCommunityCommand;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1602,15 +1602,15 @@ Expected: FAIL — `SeedTestCommunityCommand` class does not exist.
 
 declare(strict_types=1);
 
-namespace Giiken\Console;
+namespace App\Console;
 
-use Giiken\Access\AccessTier;
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\Community\WikiSchema;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Access\AccessTier;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\Community\WikiSchema;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -1729,34 +1729,34 @@ Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
 
 ---
 
-### Task B11: Wire services in GiikenServiceProvider — register() bindings
+### Task B11: Wire services in AppServiceProvider — register() bindings
 
 **Files:**
-- Modify: `src/GiikenServiceProvider.php`
+- Modify: `src/AppServiceProvider.php`
 
 - [ ] **Step 1: Add use statements and replace the TODO block**
 
-At the top of `GiikenServiceProvider.php`, add use statements:
+At the top of `AppServiceProvider.php`, add use statements:
 
 ```php
-use Giiken\Access\KnowledgeItemAccessPolicy;
-use Giiken\Console\SeedTestCommunityCommand;
-use Giiken\Entity\Community\CommunityRepository;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Pipeline\Provider\Adapter\FakeEmbeddingAdapter;
-use Giiken\Pipeline\Provider\Adapter\NullLlmAdapter;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
-use Giiken\Query\QaService;
-use Giiken\Query\QaServiceInterface;
-use Giiken\Query\Report\GovernanceSummaryReport;
-use Giiken\Query\Report\LandBriefReport;
-use Giiken\Query\Report\LanguageReport;
-use Giiken\Query\Report\ReportService;
-use Giiken\Query\Report\ReportServiceInterface;
-use Giiken\Query\SearchService;
+use App\Access\KnowledgeItemAccessPolicy;
+use App\Console\SeedTestCommunityCommand;
+use App\Entity\Community\CommunityRepository;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeItemRepository;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Pipeline\Provider\Adapter\FakeEmbeddingAdapter;
+use App\Pipeline\Provider\Adapter\NullLlmAdapter;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Provider\LlmProviderInterface;
+use App\Query\QaService;
+use App\Query\QaServiceInterface;
+use App\Query\Report\GovernanceSummaryReport;
+use App\Query\Report\LandBriefReport;
+use App\Query\Report\LanguageReport;
+use App\Query\Report\ReportService;
+use App\Query\Report\ReportServiceInterface;
+use App\Query\SearchService;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Waaseyaa\AI\Vector\Testing\FakeEmbeddingProvider;
 use Waaseyaa\AiAgent\Provider\NullLlmProvider;
@@ -1876,8 +1876,8 @@ Expected: 173+ tests still green, plus the new migration/adapter/command tests. 
 - [ ] **Step 3: Commit**
 
 ```bash
-git add src/GiikenServiceProvider.php
-git commit -m "feat: wire Phase 3 services in GiikenServiceProvider
+git add src/AppServiceProvider.php
+git commit -m "feat: wire Phase 3 services in AppServiceProvider
 
 Replaces the Phase 3 TODO block with real DI bindings for:
 - CommunityRepository / KnowledgeItemRepository (via EntityTypeManager)
@@ -1897,11 +1897,11 @@ Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
 ### Task B12: Register SeedTestCommunityCommand via commands()
 
 **Files:**
-- Modify: `src/GiikenServiceProvider.php`
+- Modify: `src/AppServiceProvider.php`
 
 - [ ] **Step 1: Add `commands()` override**
 
-Append below `routes()` in `GiikenServiceProvider`:
+Append below `routes()` in `AppServiceProvider`:
 
 ```php
 /**
@@ -1942,10 +1942,10 @@ Expected output includes `giiken:seed:test-community`.
 - [ ] **Step 4: Commit**
 
 ```bash
-git add src/GiikenServiceProvider.php
+git add src/AppServiceProvider.php
 git commit -m "feat: register giiken:seed:test-community command
 
-Exposes the seed command to the CLI via GiikenServiceProvider::commands(),
+Exposes the seed command to the CLI via AppServiceProvider::commands(),
 constructing repositories from the framework-supplied EntityTypeManager.
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
@@ -1967,7 +1967,7 @@ This test boots the full HttpKernel against in-memory SQLite, runs migrations, r
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Integration\Boot;
+namespace App\Tests\Integration\Boot;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -2153,7 +2153,7 @@ gh pr create --repo waaseyaa/giiken --title "feat: boot-to-browser — Discovery
 
 Gets \`http://127.0.0.1:8765/test-community\` rendering the Discovery homepage with real services, a real SQLite database, and a seeded test community. No hacks, no stubs in production code paths.
 
-Closes the Phase 3 service-wiring TODO block in GiikenServiceProvider.
+Closes the Phase 3 service-wiring TODO block in AppServiceProvider.
 
 Depends on framework PR: waaseyaa/framework feat/boot-to-browser-dx (ServeCommand dev env, make:public, NullLlmProvider, EntitySchemaSync).
 
@@ -2161,7 +2161,7 @@ Depends on framework PR: waaseyaa/framework feat/boot-to-browser-dx (ServeComman
 
 - **Front controller:** \`public/index.php\` scaffolded via \`waaseyaa make:public\`
 - **Migration:** \`migrations/001_ensure_entity_tables.php\` uses \`EntitySchemaSync\` to materialize community, knowledge_item, and wiki_lint_report tables from their EntityType specs
-- **DI wiring:** real bindings for \`CommunityRepository\`, \`KnowledgeItemRepository\`, \`Fts5SearchProvider\`, \`SearchService\`, \`QaService\`, \`ReportService\` in \`GiikenServiceProvider::register()\`
+- **DI wiring:** real bindings for \`CommunityRepository\`, \`KnowledgeItemRepository\`, \`Fts5SearchProvider\`, \`SearchService\`, \`QaService\`, \`ReportService\` in \`AppServiceProvider::register()\`
 - **Provider adapters:** \`FakeEmbeddingAdapter\`, \`NullLlmAdapter\` bridge framework provider implementations to Giiken's local interfaces (dev defaults; see #40)
 - **Seed command:** \`giiken:seed:test-community\` creates a community with a default \`WikiSchema\` and three public-tier sample knowledge items (idempotent)
 - **Acceptance test:** integration test that boots the kernel, runs migrations, seeds, and dispatches \`GET /test-community\`
@@ -2207,7 +2207,7 @@ gh pr view --repo waaseyaa/giiken
 | §3.1 EntitySchemaSync (Risk A contingency) | A9, A10 |
 | §3.2 public/index.php via make:public | B2 |
 | §3.2 migrations/001_ensure_entity_tables.php | B3, B4 |
-| §3.2 GiikenServiceProvider::register bindings | B11 |
+| §3.2 AppServiceProvider::register bindings | B11 |
 | §3.2 FakeEmbeddingAdapter | B5, B6 |
 | §3.2 NullLlmAdapter | B7, B8 |
 | §3.2 SeedTestCommunityCommand | B9, B10, B12 |

--- a/docs/superpowers/plans/2026-04-05-phase2-completion.md
+++ b/docs/superpowers/plans/2026-04-05-phase2-completion.md
@@ -144,9 +144,9 @@ Create `tests/Unit/Entity/Community/WikiSchemaTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Entity\Community;
+namespace App\Tests\Unit\Entity\Community;
 
-use Giiken\Entity\Community\WikiSchema;
+use App\Entity\Community\WikiSchema;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -251,7 +251,7 @@ Create `src/Entity/Community/WikiSchema.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Entity\Community;
+namespace App\Entity\Community;
 
 final class WikiSchema
 {
@@ -316,10 +316,10 @@ Create `tests/Unit/Entity/Community/CommunityWikiSchemaTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Entity\Community;
+namespace App\Tests\Unit\Entity\Community;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\WikiSchema;
+use App\Entity\Community\Community;
+use App\Entity\Community\WikiSchema;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -403,7 +403,7 @@ public function getTypedWikiSchema(): WikiSchema
 Add the import at the top of the file:
 
 ```php
-use Giiken\Entity\Community\WikiSchema;
+use App\Entity\Community\WikiSchema;
 ```
 
 - [ ] **Step 9: Run test to verify it passes**
@@ -447,11 +447,11 @@ Create `tests/Unit/Wiki/Check/OrphanPageCheckTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Wiki\Check;
+namespace App\Tests\Unit\Wiki\Check;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Wiki\Check\LintCheckInterface;
-use Giiken\Wiki\Check\OrphanPageCheck;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Wiki\Check\LintCheckInterface;
+use App\Wiki\Check\OrphanPageCheck;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -545,9 +545,9 @@ Create `src/Wiki/Check/LintCheckInterface.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Wiki\Check;
+namespace App\Wiki\Check;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 interface LintCheckInterface
 {
@@ -570,9 +570,9 @@ Create `src/Wiki/Check/OrphanPageCheck.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Wiki\Check;
+namespace App\Wiki\Check;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 final class OrphanPageCheck implements LintCheckInterface
 {
@@ -648,11 +648,11 @@ Create `tests/Unit/Wiki/Check/BrokenLinkCheckTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Wiki\Check;
+namespace App\Tests\Unit\Wiki\Check;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Wiki\Check\BrokenLinkCheck;
-use Giiken\Wiki\Check\LintCheckInterface;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Wiki\Check\BrokenLinkCheck;
+use App\Wiki\Check\LintCheckInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -749,9 +749,9 @@ Create `src/Wiki/Check/BrokenLinkCheck.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Wiki\Check;
+namespace App\Wiki\Check;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 final class BrokenLinkCheck implements LintCheckInterface
 {
@@ -825,7 +825,7 @@ Create `src/Wiki/WikiLintReport.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Wiki;
+namespace App\Wiki;
 
 use Waaseyaa\Entity\ContentEntityBase;
 
@@ -916,14 +916,14 @@ Create `tests/Unit/Wiki/WikiLintJobTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Wiki;
+namespace App\Tests\Unit\Wiki;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Wiki\Check\BrokenLinkCheck;
-use Giiken\Wiki\Check\LintCheckInterface;
-use Giiken\Wiki\Check\OrphanPageCheck;
-use Giiken\Wiki\WikiLintJob;
-use Giiken\Wiki\WikiLintReport;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Wiki\Check\BrokenLinkCheck;
+use App\Wiki\Check\LintCheckInterface;
+use App\Wiki\Check\OrphanPageCheck;
+use App\Wiki\WikiLintJob;
+use App\Wiki\WikiLintReport;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1031,9 +1031,9 @@ Create `src/Wiki/WikiLintJob.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Wiki;
+namespace App\Wiki;
 
-use Giiken\Wiki\Check\LintCheckInterface;
+use App\Wiki\Check\LintCheckInterface;
 use Waaseyaa\Entity\EntityRepositoryInterface;
 
 final class WikiLintJob
@@ -1107,15 +1107,15 @@ git commit -m "feat(#23): add WikiLintJob orchestrating checks and saving report
 
 ---
 
-## Task 7: Register wiki entities in GiikenServiceProvider
+## Task 7: Register wiki entities in AppServiceProvider
 
 **Files:**
-- Modify: `src/GiikenServiceProvider.php`
-- Modify: `tests/Unit/GiikenServiceProviderTest.php` (if entity registration is tested there)
+- Modify: `src/AppServiceProvider.php`
+- Modify: `tests/Unit/AppServiceProviderTest.php` (if entity registration is tested there)
 
 - [ ] **Step 1: Read the current service provider**
 
-Read `src/GiikenServiceProvider.php` to understand the registration pattern.
+Read `src/AppServiceProvider.php` to understand the registration pattern.
 
 - [ ] **Step 2: Add WikiLintReport entity type registration**
 
@@ -1124,7 +1124,7 @@ Add the `wiki_lint_report` entity type to the service provider's entity type reg
 - [ ] **Step 3: Run existing service provider test**
 
 ```bash
-./vendor/bin/phpunit tests/Unit/GiikenServiceProviderTest.php
+./vendor/bin/phpunit tests/Unit/AppServiceProviderTest.php
 ```
 
 Expected: PASS (may need test update if it asserts entity type count).
@@ -1132,7 +1132,7 @@ Expected: PASS (may need test update if it asserts entity type count).
 - [ ] **Step 4: Commit**
 
 ```bash
-git add src/GiikenServiceProvider.php tests/Unit/GiikenServiceProviderTest.php
+git add src/AppServiceProvider.php tests/Unit/AppServiceProviderTest.php
 git commit -m "feat(#23): register wiki_lint_report entity type in service provider"
 ```
 

--- a/docs/superpowers/plans/2026-04-05-phase3-query-layer.md
+++ b/docs/superpowers/plans/2026-04-05-phase3-query-layer.md
@@ -4,7 +4,7 @@
 
 **Goal:** Build hybrid search, RAG Q&A, report generation, data export/import, and audio/video ingestion on top of the Phase 2 ingestion pipeline.
 
-**Architecture:** Two implementation units — Unit 1 (Search + Q&A) provides hybrid full-text/semantic search and RAG-based question answering; Unit 2 (Reports + Export) provides report rendering and sovereign data portability. A standalone media handler adds audio/video ingestion. All new services are wired through GiikenServiceProvider.
+**Architecture:** Two implementation units — Unit 1 (Search + Q&A) provides hybrid full-text/semantic search and RAG-based question answering; Unit 2 (Reports + Export) provides report rendering and sovereign data portability. A standalone media handler adds audio/video ingestion. All new services are wired through AppServiceProvider.
 
 **Tech Stack:** PHP 8.4, PHPUnit 10.5, Waaseyaa framework (search, ai-vector, queue, media, entity, access packages)
 
@@ -40,7 +40,7 @@
 |------|--------|
 | `src/Entity/KnowledgeItem/KnowledgeItem.php` | Implement `SearchIndexableInterface` |
 | `src/Entity/KnowledgeItem/KnowledgeItemRepository.php` | Add `SearchIndexerInterface` indexing on save |
-| `src/GiikenServiceProvider.php` | Register all new services |
+| `src/AppServiceProvider.php` | Register all new services |
 
 ### Test Files
 
@@ -78,9 +78,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query;
+namespace App\Tests\Unit\Query;
 
-use Giiken\Query\SearchQuery;
+use App\Query\SearchQuery;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -133,11 +133,11 @@ final class SearchQueryTest extends TestCase
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query;
+namespace App\Tests\Unit\Query;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Query\SearchResultItem;
-use Giiken\Query\SearchResultSet;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Query\SearchResultItem;
+use App\Query\SearchResultSet;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -193,7 +193,7 @@ Expected: FAIL — classes not found
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
 final readonly class SearchQuery
 {
@@ -217,9 +217,9 @@ final readonly class SearchQuery
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Entity\KnowledgeItem\KnowledgeType;
 
 final readonly class SearchResultItem
 {
@@ -240,7 +240,7 @@ final readonly class SearchResultItem
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
 final readonly class SearchResultSet
 {
@@ -288,11 +288,11 @@ git commit -m "feat(query): add search value objects (SearchQuery, SearchResultI
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Entity\KnowledgeItem;
+namespace App\Tests\Unit\Entity\KnowledgeItem;
 
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -444,16 +444,16 @@ git commit -m "feat(entity): KnowledgeItem implements SearchIndexableInterface"
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query;
+namespace App\Tests\Unit\Query;
 
-use Giiken\Access\KnowledgeItemAccessPolicy;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Query\SearchQuery;
-use Giiken\Query\SearchService;
+use App\Access\KnowledgeItemAccessPolicy;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepository;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Query\SearchQuery;
+use App\Query\SearchService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -719,12 +719,12 @@ Expected: FAIL — SearchService class not found
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
-use Giiken\Access\KnowledgeItemAccessPolicy;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Access\KnowledgeItemAccessPolicy;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepository;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Search\SearchFilters;
 use Waaseyaa\Search\SearchProviderInterface;
@@ -1023,16 +1023,16 @@ git commit -m "feat(query): hybrid search service with access control and FTS in
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query;
+namespace App\Tests\Unit\Query;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
-use Giiken\Query\QaResponse;
-use Giiken\Query\QaService;
-use Giiken\Query\SearchQuery;
-use Giiken\Query\SearchResultItem;
-use Giiken\Query\SearchResultSet;
-use Giiken\Query\SearchService;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Pipeline\Provider\LlmProviderInterface;
+use App\Query\QaResponse;
+use App\Query\QaService;
+use App\Query\SearchQuery;
+use App\Query\SearchResultItem;
+use App\Query\SearchResultSet;
+use App\Query\SearchService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1151,7 +1151,7 @@ Expected: FAIL — QaService class not found
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
 final readonly class QaResponse
 {
@@ -1173,9 +1173,9 @@ final readonly class QaResponse
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
-use Giiken\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\Provider\LlmProviderInterface;
 use Waaseyaa\Access\AccountInterface;
 
 final class QaService
@@ -1277,9 +1277,9 @@ git commit -m "feat(query): RAG-based Q&A service with citation parsing"
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query\Report;
+namespace App\Tests\Unit\Query\Report;
 
-use Giiken\Query\Report\DateRange;
+use App\Query\Report\DateRange;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1320,14 +1320,14 @@ final class DateRangeTest extends TestCase
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query\Report;
+namespace App\Tests\Unit\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Query\Report\DateRange;
-use Giiken\Query\Report\GovernanceSummaryReport;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Query\Report\DateRange;
+use App\Query\Report\GovernanceSummaryReport;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1406,7 +1406,7 @@ Expected: FAIL — classes not found
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
 final readonly class DateRange
 {
@@ -1429,10 +1429,10 @@ final readonly class DateRange
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 interface ReportRendererInterface
 {
@@ -1452,10 +1452,10 @@ interface ReportRendererInterface
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 final class GovernanceSummaryReport implements ReportRendererInterface
 {
@@ -1526,14 +1526,14 @@ git commit -m "feat(report): DateRange, ReportRendererInterface, GovernanceSumma
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query\Report;
+namespace App\Tests\Unit\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Query\Report\DateRange;
-use Giiken\Query\Report\LanguageReport;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Query\Report\DateRange;
+use App\Query\Report\LanguageReport;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1598,14 +1598,14 @@ final class LanguageReportTest extends TestCase
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query\Report;
+namespace App\Tests\Unit\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Query\Report\DateRange;
-use Giiken\Query\Report\LandBriefReport;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Query\Report\DateRange;
+use App\Query\Report\LandBriefReport;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1675,10 +1675,10 @@ Expected: FAIL — classes not found
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 final class LanguageReport implements ReportRendererInterface
 {
@@ -1725,10 +1725,10 @@ final class LanguageReport implements ReportRendererInterface
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 final class LandBriefReport implements ReportRendererInterface
 {
@@ -1796,19 +1796,19 @@ git commit -m "feat(report): LanguageReport and LandBriefReport renderers"
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query\Report;
+namespace App\Tests\Unit\Query\Report;
 
-use Giiken\Access\CommunityRole;
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Query\Report\DateRange;
-use Giiken\Query\Report\GovernanceSummaryReport;
-use Giiken\Query\Report\LandBriefReport;
-use Giiken\Query\Report\LanguageReport;
-use Giiken\Query\Report\ReportService;
+use App\Access\CommunityRole;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepository;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Query\Report\DateRange;
+use App\Query\Report\GovernanceSummaryReport;
+use App\Query\Report\LandBriefReport;
+use App\Query\Report\LanguageReport;
+use App\Query\Report\ReportService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -1985,13 +1985,13 @@ Expected: FAIL — ReportService class not found
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
-use Giiken\Access\CommunityRole;
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Access\CommunityRole;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepository;
+use App\Entity\KnowledgeItem\KnowledgeType;
 use Waaseyaa\Access\AccountInterface;
 
 final class ReportService
@@ -2125,16 +2125,16 @@ git commit -m "feat(report): ReportService with role-based access and date filte
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Export;
+namespace App\Tests\Unit\Export;
 
-use Giiken\Access\CommunityRole;
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Export\ExportService;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Access\CommunityRole;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepository;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Export\ExportService;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -2304,13 +2304,13 @@ Expected: FAIL — ExportService class not found
 
 declare(strict_types=1);
 
-namespace Giiken\Export;
+namespace App\Export;
 
-use Giiken\Access\CommunityRole;
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Access\CommunityRole;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepository;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Media\FileRepositoryInterface;
 
@@ -2553,18 +2553,18 @@ git commit -m "feat(export): ExportService produces ZIP archive with community d
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Export;
+namespace App\Tests\Unit\Export;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepository;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Export\ExportService;
-use Giiken\Export\ImportResult;
-use Giiken\Export\ImportService;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepository;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepository;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Export\ExportService;
+use App\Export\ImportResult;
+use App\Export\ImportService;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -2695,7 +2695,7 @@ Expected: FAIL — ImportService class not found
 
 declare(strict_types=1);
 
-namespace Giiken\Export;
+namespace App\Export;
 
 final readonly class ImportResult
 {
@@ -2718,12 +2718,12 @@ final readonly class ImportResult
 
 declare(strict_types=1);
 
-namespace Giiken\Export;
+namespace App\Export;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepository;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepository;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepository;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Media\FileRepositoryInterface;
 
@@ -2969,11 +2969,11 @@ git commit -m "feat(export): ImportService with round-trip support"
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Handler;
+namespace App\Tests\Unit\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Handler\MediaIngestionHandler;
-use Giiken\Ingestion\IngestionException;
+use App\Entity\Community\Community;
+use App\Ingestion\Handler\MediaIngestionHandler;
+use App\Ingestion\IngestionException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -3099,12 +3099,12 @@ Expected: FAIL — MediaIngestionHandler class not found
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Handler;
+namespace App\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\RawDocument;
 use Waaseyaa\Media\File;
 use Waaseyaa\Media\FileRepositoryInterface;
 use Waaseyaa\Queue\QueueInterface;
@@ -3157,7 +3157,7 @@ final class MediaIngestionHandler implements FileIngestionHandlerInterface
         $savedFile = $this->mediaRepo->save($file);
         $mediaId = $savedFile->uri;
 
-        $this->queue->dispatch(new \Giiken\Ingestion\Job\TranscribeJob(
+        $this->queue->dispatch(new \App\Ingestion\Job\TranscribeJob(
             mediaId: $mediaId,
             communityId: (string) $community->get('id'),
             originalFilename: $originalFilename,
@@ -3194,12 +3194,12 @@ Expected: FAIL — TranscribeJob class not found (needed by MediaIngestionHandle
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Job;
+namespace App\Tests\Unit\Ingestion\Job;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
-use Giiken\Ingestion\Job\TranscribeJob;
-use Giiken\Pipeline\Step\TranscribeStep;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepository;
+use App\Ingestion\Job\TranscribeJob;
+use App\Pipeline\Step\TranscribeStep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -3261,7 +3261,7 @@ Expected: FAIL — TranscribeJob class not found
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Job;
+namespace App\Ingestion\Job;
 
 use Waaseyaa\Queue\Job;
 
@@ -3311,32 +3311,32 @@ git commit -m "feat(ingestion): audio/video handler with async TranscribeJob"
 
 ---
 
-## Task 12: GiikenServiceProvider Wiring
+## Task 12: AppServiceProvider Wiring
 
 **Files:**
-- Modify: `src/GiikenServiceProvider.php`
+- Modify: `src/AppServiceProvider.php`
 
 - [ ] **Step 1: Run all tests before modifying**
 
 Run: `./vendor/bin/phpunit`
 Expected: All tests pass
 
-- [ ] **Step 2: Update GiikenServiceProvider**
+- [ ] **Step 2: Update AppServiceProvider**
 
-In `src/GiikenServiceProvider.php`, add the new service registrations. The register method should document the Phase 3 services. Since the Waaseyaa DI container specifics aren't defined yet in the service provider pattern, add a comment block documenting the wiring:
+In `src/AppServiceProvider.php`, add the new service registrations. The register method should document the Phase 3 services. Since the Waaseyaa DI container specifics aren't defined yet in the service provider pattern, add a comment block documenting the wiring:
 
 Add imports at the top of the file:
 
 ```php
-use Giiken\Query\SearchService;
-use Giiken\Query\QaService;
-use Giiken\Query\Report\ReportService;
-use Giiken\Query\Report\GovernanceSummaryReport;
-use Giiken\Query\Report\LanguageReport;
-use Giiken\Query\Report\LandBriefReport;
-use Giiken\Export\ExportService;
-use Giiken\Export\ImportService;
-use Giiken\Ingestion\Handler\MediaIngestionHandler;
+use App\Query\SearchService;
+use App\Query\QaService;
+use App\Query\Report\ReportService;
+use App\Query\Report\GovernanceSummaryReport;
+use App\Query\Report\LanguageReport;
+use App\Query\Report\LandBriefReport;
+use App\Export\ExportService;
+use App\Export\ImportService;
+use App\Ingestion\Handler\MediaIngestionHandler;
 ```
 
 Replace the comment at the end of the class:
@@ -3371,8 +3371,8 @@ Expected: No errors (or only pre-existing ones)
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/GiikenServiceProvider.php
-git commit -m "feat(provider): document Phase 3 service wiring in GiikenServiceProvider"
+git add src/AppServiceProvider.php
+git commit -m "feat(provider): document Phase 3 service wiring in AppServiceProvider"
 ```
 
 - [ ] **Step 6: Final full test run**

--- a/docs/superpowers/plans/2026-04-05-phase4-frontend.md
+++ b/docs/superpowers/plans/2026-04-05-phase4-frontend.md
@@ -4,7 +4,7 @@
 
 **Goal:** Build the Inertia.js frontend so Giiken is usable in a browser: search, Q&A, knowledge browsing, and staff management panel.
 
-**Architecture:** Vue 3 + Inertia.js rendered by PHP controllers registered in `GiikenServiceProvider::routes()`. The Waaseyaa framework provides `Inertia::render()`, `InertiaMiddleware`, `ControllerDispatcher`, and `ViteAssetManager`. Controllers are closures returning `InertiaResponse`. Two surfaces in one app: Discovery (all users) and Management (staff+).
+**Architecture:** Vue 3 + Inertia.js rendered by PHP controllers registered in `AppServiceProvider::routes()`. The Waaseyaa framework provides `Inertia::render()`, `InertiaMiddleware`, `ControllerDispatcher`, and `ViteAssetManager`. Controllers are closures returning `InertiaResponse`. Two surfaces in one app: Discovery (all users) and Management (staff+).
 
 **Tech Stack:** Vue 3, TypeScript, Inertia.js (via `waaseyaa/inertia`), Vite, Tailwind CSS v4, PHP 8.4 controllers
 
@@ -60,7 +60,7 @@ src/
 │   │   └── ManagementController.php     # Dashboard, reports, users, ingestion, export
 │   └── Middleware/
 │       └── RequireStaffRole.php         # Guards management routes
-├── GiikenServiceProvider.php            # MODIFY: add routes
+├── AppServiceProvider.php            # MODIFY: add routes
 ```
 
 ### Tests
@@ -287,7 +287,7 @@ git commit -m "feat: scaffold frontend tooling (Vue 3, Vite, Tailwind, Inertia)"
 **Files:**
 - Create: `src/Http/Controller/DiscoveryController.php`
 - Create: `tests/Unit/Http/Controller/DiscoveryControllerTest.php`
-- Modify: `src/GiikenServiceProvider.php`
+- Modify: `src/AppServiceProvider.php`
 
 - [ ] **Step 1: Write the failing test for DiscoveryController**
 
@@ -298,20 +298,20 @@ Create `tests/Unit/Http/Controller/DiscoveryControllerTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Http\Controller;
+namespace App\Tests\Unit\Http\Controller;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Http\Controller\DiscoveryController;
-use Giiken\Query\QaResponse;
-use Giiken\Query\QaService;
-use Giiken\Query\SearchQuery;
-use Giiken\Query\SearchResultItem;
-use Giiken\Query\SearchResultSet;
-use Giiken\Query\SearchService;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Http\Controller\DiscoveryController;
+use App\Query\QaResponse;
+use App\Query\QaService;
+use App\Query\SearchQuery;
+use App\Query\SearchResultItem;
+use App\Query\SearchResultSet;
+use App\Query\SearchService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -439,13 +439,13 @@ Create `src/Http/Controller/DiscoveryController.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Http\Controller;
+namespace App\Http\Controller;
 
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Query\QaService;
-use Giiken\Query\SearchQuery;
-use Giiken\Query\SearchService;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Query\QaService;
+use App\Query\SearchQuery;
+use App\Query\SearchService;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Inertia\Inertia;
 use Waaseyaa\Inertia\InertiaResponse;
@@ -541,7 +541,7 @@ final class DiscoveryController
         ]);
     }
 
-    private function serializeCommunity(\Giiken\Entity\Community\Community $community): array
+    private function serializeCommunity(\App\Entity\Community\Community $community): array
     {
         return [
             'id' => $community->get('id'),
@@ -551,7 +551,7 @@ final class DiscoveryController
         ];
     }
 
-    private function serializeResultSet(\Giiken\Query\SearchResultSet $resultSet): array
+    private function serializeResultSet(\App\Query\SearchResultSet $resultSet): array
     {
         return [
             'items' => array_map(fn ($item) => [
@@ -599,9 +599,9 @@ Create `tests/Unit/Http/Middleware/RequireStaffRoleTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Http\Middleware;
+namespace App\Tests\Unit\Http\Middleware;
 
-use Giiken\Http\Middleware\RequireStaffRole;
+use App\Http\Middleware\RequireStaffRole;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -681,9 +681,9 @@ Create `src/Http/Middleware/RequireStaffRole.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Http\Middleware;
+namespace App\Http\Middleware;
 
-use Giiken\Access\CommunityRole;
+use App\Access\CommunityRole;
 use Waaseyaa\Access\AccountInterface;
 
 final class RequireStaffRole
@@ -730,14 +730,14 @@ Create `tests/Unit/Http/Controller/ManagementControllerTest.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Http\Controller;
+namespace App\Tests\Unit\Http\Controller;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Http\Controller\ManagementController;
-use Giiken\Query\Export\ExportService;
-use Giiken\Query\Export\ImportService;
-use Giiken\Query\Report\ReportService;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Http\Controller\ManagementController;
+use App\Query\Export\ExportService;
+use App\Query\Export\ImportService;
+use App\Query\Report\ReportService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -827,13 +827,13 @@ Create `src/Http/Controller/ManagementController.php`:
 
 declare(strict_types=1);
 
-namespace Giiken\Http\Controller;
+namespace App\Http\Controller;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Query\Export\ExportService;
-use Giiken\Query\Export\ImportService;
-use Giiken\Query\Report\ReportService;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Query\Export\ExportService;
+use App\Query\Export\ImportService;
+use App\Query\Report\ReportService;
 use Waaseyaa\Inertia\Inertia;
 use Waaseyaa\Inertia\InertiaResponse;
 
@@ -921,9 +921,9 @@ git commit -m "feat: add RequireStaffRole middleware and ManagementController"
 ## Task 4: Route Registration
 
 **Files:**
-- Modify: `src/GiikenServiceProvider.php`
+- Modify: `src/AppServiceProvider.php`
 
-- [ ] **Step 1: Add routes to GiikenServiceProvider**
+- [ ] **Step 1: Add routes to AppServiceProvider**
 
 Add the following use statements and route definitions inside `routes()`:
 
@@ -1007,7 +1007,7 @@ Expected: No errors
 - [ ] **Step 4: Commit**
 
 ```bash
-git add src/GiikenServiceProvider.php
+git add src/AppServiceProvider.php
 git commit -m "feat: register discovery and management routes"
 ```
 

--- a/docs/superpowers/plans/2026-04-12-discovery-surface.md
+++ b/docs/superpowers/plans/2026-04-12-discovery-surface.md
@@ -1,0 +1,594 @@
+# Discovery Surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add config coverage tests (#86), SearchHero + BrowseStrip components (#18), and DOM snapshot tests (#84) in a single PR.
+
+**Architecture:** Three commits in sequence. First adds a `KNOWLEDGE_TYPES` array to `types.ts` and a test that validates TS-PHP enum sync. Second builds `SearchHero.vue` and `BrowseStrip.vue`, wires them into `Discover.vue`. Third adds DOM snapshots for all Vue components including the new ones.
+
+**Tech Stack:** Vue 3, TypeScript, Vitest, Vue Test Utils, Inertia.js, Tailwind CSS v4
+
+---
+
+## File Map
+
+### New files
+| File | Responsibility |
+|------|---------------|
+| `tests/js/KnowledgeTypeConfig.test.ts` | Config coverage + PHP-TS sync invariants |
+| `resources/js/Components/SearchHero.vue` | Root-level gradient hero with search input |
+| `resources/js/Components/BrowseStrip.vue` | Knowledge-type navigation chip strip |
+| `tests/js/snapshots.test.ts` | DOM snapshot tests for all Vue components |
+
+### Modified files
+| File | Change |
+|------|--------|
+| `resources/js/types.ts` | Add `KNOWLEDGE_TYPES` array export |
+| `resources/js/Pages/Discover.vue` | Replace `<header>` with SearchHero + BrowseStrip |
+
+---
+
+## Task 1: Add KNOWLEDGE_TYPES array to types.ts
+
+**Files:**
+- Modify: `resources/js/types.ts`
+
+- [ ] **Step 1: Add KNOWLEDGE_TYPES export**
+
+In `resources/js/types.ts`, after the `KnowledgeType` type definition (line 16), add:
+
+```ts
+export const KNOWLEDGE_TYPES = [
+  'cultural', 'governance', 'land', 'relationship', 'event',
+] as const satisfies readonly KnowledgeType[]
+```
+
+This goes between the `KnowledgeType` type (line 16) and the `AccessTier` type (line 17).
+
+- [ ] **Step 2: Verify no type errors**
+
+Run: `npx vue-tsc --noEmit`
+Expected: Clean exit, no errors.
+
+---
+
+## Task 2: Write config coverage test (invariant 1 — TS-side)
+
+**Files:**
+- Create: `tests/js/KnowledgeTypeConfig.test.ts`
+
+- [ ] **Step 1: Write the TS completeness test**
+
+Create `tests/js/KnowledgeTypeConfig.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { KNOWLEDGE_TYPES, KNOWLEDGE_TYPE_CONFIG } from '@/types'
+
+describe('KNOWLEDGE_TYPE_CONFIG', () => {
+  it('has an entry for every member of KNOWLEDGE_TYPES', () => {
+    const configKeys = Object.keys(KNOWLEDGE_TYPE_CONFIG).sort()
+    const typesList = [...KNOWLEDGE_TYPES].sort()
+    expect(configKeys).toEqual(typesList)
+  })
+
+  it('every config entry has required style properties', () => {
+    for (const type of KNOWLEDGE_TYPES) {
+      const entry = KNOWLEDGE_TYPE_CONFIG[type]
+      expect(entry).toHaveProperty('label')
+      expect(entry).toHaveProperty('chip')
+      expect(entry).toHaveProperty('activeChip')
+      expect(entry).toHaveProperty('dot')
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `npm run test:js -- --run tests/js/KnowledgeTypeConfig.test.ts`
+Expected: 2 tests PASS.
+
+---
+
+## Task 3: Write PHP-TS sync test (invariant 2)
+
+**Files:**
+- Modify: `tests/js/KnowledgeTypeConfig.test.ts`
+
+- [ ] **Step 1: Add the PHP-TS sync invariant**
+
+Append to `tests/js/KnowledgeTypeConfig.test.ts`, inside the existing `describe` block, after the last `it()`:
+
+```ts
+  const EXPECTED_FUTURE = new Set(['synthesis'])
+
+  it('every PHP KnowledgeType case is in KNOWLEDGE_TYPES or EXPECTED_FUTURE', async () => {
+    const fs = await import('node:fs/promises')
+    const path = await import('node:path')
+    const phpPath = path.resolve(__dirname, '../../src/Entity/KnowledgeItem/KnowledgeType.php')
+    const phpSource = await fs.readFile(phpPath, 'utf-8')
+    const caseRegex = /case\s+\w+\s*=\s*'(\w+)'/g
+    const phpCases: string[] = []
+    let match: RegExpExecArray | null
+    while ((match = caseRegex.exec(phpSource)) !== null) {
+      phpCases.push(match[1])
+    }
+
+    expect(phpCases.length).toBeGreaterThan(0)
+
+    const tsSet = new Set<string>(KNOWLEDGE_TYPES)
+    for (const phpCase of phpCases) {
+      const inTs = tsSet.has(phpCase)
+      const inFuture = EXPECTED_FUTURE.has(phpCase)
+      expect(
+        inTs || inFuture,
+        `PHP case '${phpCase}' is not in KNOWLEDGE_TYPES or EXPECTED_FUTURE`,
+      ).toBe(true)
+    }
+  })
+
+  it('EXPECTED_FUTURE has no members already in KNOWLEDGE_TYPES', () => {
+    const tsSet = new Set<string>(KNOWLEDGE_TYPES)
+    for (const futureType of EXPECTED_FUTURE) {
+      expect(
+        tsSet.has(futureType),
+        `'${futureType}' is in both EXPECTED_FUTURE and KNOWLEDGE_TYPES — remove it from EXPECTED_FUTURE`,
+      ).toBe(false)
+    }
+  })
+```
+
+- [ ] **Step 2: Run all config tests**
+
+Run: `npm run test:js -- --run tests/js/KnowledgeTypeConfig.test.ts`
+Expected: 4 tests PASS.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `npm run test:js`
+Expected: All tests pass (existing + new).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/types.ts tests/js/KnowledgeTypeConfig.test.ts
+git commit -m "feat(#86): add KNOWLEDGE_TYPES array and config coverage test
+
+Two runtime invariants:
+1. KNOWLEDGE_TYPE_CONFIG keys match KNOWLEDGE_TYPES array
+2. Every PHP KnowledgeType enum case exists in TS or EXPECTED_FUTURE
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Create SearchHero component
+
+**Files:**
+- Create: `resources/js/Components/SearchHero.vue`
+
+- [ ] **Step 1: Create SearchHero.vue**
+
+Create `resources/js/Components/SearchHero.vue`:
+
+```vue
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { router } from '@inertiajs/vue3'
+
+interface CommunitySummary {
+  id: number | string
+  name: string
+  slug: string
+  locale: string
+}
+
+const props = defineProps<{
+  communities: CommunitySummary[]
+}>()
+
+const query = ref('')
+const selectedSlug = computed(() => {
+  if (props.communities.length === 1) return props.communities[0].slug
+  return manualSlug.value
+})
+const manualSlug = ref(props.communities[0]?.slug ?? '')
+
+function submit() {
+  const q = query.value.trim()
+  if (!q || !selectedSlug.value) return
+
+  const isQuestion = q.includes('?') || q.split(/\s+/).length > 5
+  const route = isQuestion
+    ? `/${selectedSlug.value}/ask`
+    : `/${selectedSlug.value}/search`
+
+  router.get(route, { q, page: 1 })
+}
+</script>
+
+<template>
+  <header class="bg-gradient-to-br from-primary to-primary-hover text-on-primary py-20 px-6 text-center">
+    <h1 class="text-4xl font-bold mb-3">Sovereign Indigenous Knowledge</h1>
+    <p class="text-primary-subtle text-lg max-w-2xl mx-auto mb-10">
+      Browse community knowledge bases. Each community governs its own content under its own protocols.
+    </p>
+
+    <form
+      v-if="communities.length > 0"
+      class="flex items-center justify-center gap-2 max-w-2xl mx-auto"
+      @submit.prevent="submit"
+    >
+      <select
+        v-if="communities.length > 1"
+        v-model="manualSlug"
+        class="px-3 py-3 rounded-lg border border-border text-ink text-base"
+      >
+        <option v-for="c in communities" :key="c.id" :value="c.slug">
+          {{ c.name }}
+        </option>
+      </select>
+      <input
+        v-model="query"
+        type="text"
+        placeholder="Search or ask a question..."
+        class="flex-1 px-4 py-3 rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary text-ink text-base"
+      />
+      <button
+        type="submit"
+        class="px-6 py-3 bg-surface text-primary rounded-lg hover:bg-surface-raised font-medium"
+      >
+        Ask →
+      </button>
+    </form>
+  </header>
+</template>
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run: `npx vue-tsc --noEmit`
+Expected: Clean exit.
+
+---
+
+## Task 5: Create BrowseStrip component
+
+**Files:**
+- Create: `resources/js/Components/BrowseStrip.vue`
+
+- [ ] **Step 1: Create BrowseStrip.vue**
+
+Create `resources/js/Components/BrowseStrip.vue`:
+
+```vue
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+import { KNOWLEDGE_TYPE_CONFIG } from '@/types'
+import type { KnowledgeType } from '@/types'
+
+interface CommunitySummary {
+  id: number | string
+  name: string
+  slug: string
+  locale: string
+}
+
+const props = defineProps<{
+  communities: CommunitySummary[]
+}>()
+
+const types = Object.entries(KNOWLEDGE_TYPE_CONFIG) as [KnowledgeType, typeof KNOWLEDGE_TYPE_CONFIG[KnowledgeType]][]
+const targetSlug = props.communities[0]?.slug
+</script>
+
+<template>
+  <section v-if="communities.length > 0" class="max-w-5xl mx-auto px-6 pt-8">
+    <div class="flex gap-2 overflow-x-auto flex-nowrap justify-center">
+      <Link
+        v-for="[type, config] in types"
+        :key="type"
+        :href="`/${targetSlug}?type=${type}`"
+        class="px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors"
+        :class="config.chip"
+      >
+        {{ config.label }}
+      </Link>
+    </div>
+  </section>
+</template>
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run: `npx vue-tsc --noEmit`
+Expected: Clean exit.
+
+---
+
+## Task 6: Wire SearchHero and BrowseStrip into Discover.vue
+
+**Files:**
+- Modify: `resources/js/Pages/Discover.vue`
+
+- [ ] **Step 1: Update Discover.vue**
+
+Replace the entire contents of `resources/js/Pages/Discover.vue` with:
+
+```vue
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+import SearchHero from '@/Components/SearchHero.vue'
+import BrowseStrip from '@/Components/BrowseStrip.vue'
+
+interface CommunitySummary {
+  id: number | string
+  name: string
+  slug: string
+  locale: string
+}
+
+defineProps<{
+  communities: CommunitySummary[]
+}>()
+</script>
+
+<template>
+  <div class="min-h-screen bg-surface">
+    <nav class="bg-surface-inverse text-on-inverse px-6 py-3">
+      <span class="font-bold text-lg">Giiken</span>
+    </nav>
+
+    <SearchHero :communities="communities" />
+    <BrowseStrip :communities="communities" />
+
+    <main class="max-w-5xl mx-auto px-6 py-12">
+      <h2 class="text-xl font-semibold text-ink mb-6">Communities</h2>
+
+      <div v-if="communities.length > 0" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Link
+          v-for="community in communities"
+          :key="community.id"
+          :href="`/${community.slug}`"
+          class="block p-5 bg-surface-raised rounded-lg border border-border hover:shadow-md hover:border-primary transition"
+        >
+          <h3 class="font-semibold text-ink text-lg">{{ community.name }}</h3>
+          <p class="text-sm text-ink-muted mt-1">/{{ community.slug }}</p>
+          <p class="text-xs text-ink-muted mt-3 uppercase tracking-wide">{{ community.locale }}</p>
+        </Link>
+      </div>
+
+      <div v-else class="bg-surface-raised border border-border rounded-lg p-8 text-center">
+        <p class="text-ink-muted">
+          No communities yet. Run
+          <code class="text-primary bg-primary-subtle px-2 py-0.5 rounded">./bin/waaseyaa giiken:seed:test-community</code>
+          to seed a demo community.
+        </p>
+      </div>
+    </main>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run: `npx vue-tsc --noEmit`
+Expected: Clean exit.
+
+- [ ] **Step 3: Visual smoke test**
+
+Start the dev server: `composer run dev`
+Open `http://127.0.0.1:8080/` in a browser.
+
+Verify:
+- Hero section renders with gradient, headline, and search input
+- If one seeded community exists, no `<select>` dropdown appears
+- BrowseStrip renders 5 knowledge-type chips below the hero
+- Clicking a chip navigates to `/{communitySlug}?type={type}`
+- Community grid still renders below the browse strip
+- Submitting a search query navigates to `/{slug}/search?q=...`
+- Submitting a question (contains `?` or >5 words) navigates to `/{slug}/ask?q=...`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/Components/SearchHero.vue resources/js/Components/BrowseStrip.vue resources/js/Pages/Discover.vue
+git commit -m "feat(#18): add SearchHero and BrowseStrip, rework Discover.vue
+
+SearchHero: gradient hero with embedded search input. Auto-selects
+community when only one exists, shows a <select> for multiple.
+
+BrowseStrip: knowledge-type chip strip using KNOWLEDGE_TYPE_CONFIG.
+Chips are navigation links into the community discovery surface.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Write DOM snapshot tests
+
+**Files:**
+- Create: `tests/js/snapshots.test.ts`
+
+- [ ] **Step 1: Create snapshot test file**
+
+Create `tests/js/snapshots.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import KnowledgeCard from '@/Components/KnowledgeCard.vue'
+import CitationCard from '@/Components/CitationCard.vue'
+import AnswerPanel from '@/Components/AnswerPanel.vue'
+import SearchInput from '@/Components/SearchInput.vue'
+import TypeFilter from '@/Components/TypeFilter.vue'
+import SearchHero from '@/Components/SearchHero.vue'
+import BrowseStrip from '@/Components/BrowseStrip.vue'
+import { KNOWLEDGE_TYPES } from '@/types'
+import type { KnowledgeType, Citation } from '@/types'
+
+const LinkStub = { template: '<a :href="href"><slot /></a>', props: ['href'] }
+const globalStubs = { global: { stubs: { Link: LinkStub } } }
+
+const singleCommunity = [{ id: '1', name: 'Test Nation', slug: 'test-nation', locale: 'en' }]
+const multiCommunity = [
+  { id: '1', name: 'Test Nation', slug: 'test-nation', locale: 'en' },
+  { id: '2', name: 'Second Nation', slug: 'second-nation', locale: 'fr' },
+]
+
+describe('KnowledgeCard snapshots', () => {
+  for (const type of KNOWLEDGE_TYPES) {
+    it(`renders ${type} variant`, () => {
+      const wrapper = mount(KnowledgeCard, {
+        props: {
+          id: '1',
+          title: `${type} item`,
+          summary: `A ${type} knowledge item.`,
+          knowledgeType: type as KnowledgeType,
+          communitySlug: 'test-community',
+        },
+        ...globalStubs,
+      })
+      expect(wrapper.html()).toMatchSnapshot()
+    })
+  }
+})
+
+describe('CitationCard snapshot', () => {
+  it('renders a citation', () => {
+    const citation: Citation = {
+      itemId: '10',
+      title: 'Governance doc',
+      excerpt: 'Relevant excerpt from the document.',
+      knowledgeType: 'governance',
+    }
+    const wrapper = mount(CitationCard, {
+      props: { index: 1, citation, communitySlug: 'test-community' },
+      ...globalStubs,
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe('AnswerPanel snapshot', () => {
+  it('renders an answer with citations', () => {
+    const citations: Citation[] = [
+      { itemId: '10', title: 'Doc A', excerpt: 'Excerpt A.', knowledgeType: 'cultural' },
+      { itemId: '11', title: 'Doc B', excerpt: 'Excerpt B.', knowledgeType: 'land' },
+    ]
+    const wrapper = mount(AnswerPanel, {
+      props: {
+        answer: 'This is the answer [1] with sources [2].',
+        citations,
+        communitySlug: 'test-community',
+      },
+      ...globalStubs,
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe('SearchInput snapshot', () => {
+  it('renders default state', () => {
+    const wrapper = mount(SearchInput, {
+      props: { communitySlug: 'test-community' },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe('TypeFilter snapshots', () => {
+  it('renders with no active filter', () => {
+    const wrapper = mount(TypeFilter, {
+      props: { active: null },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders with cultural active', () => {
+    const wrapper = mount(TypeFilter, {
+      props: { active: 'cultural' as KnowledgeType },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe('SearchHero snapshots', () => {
+  it('renders with single community (no select)', () => {
+    const wrapper = mount(SearchHero, {
+      props: { communities: singleCommunity },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders with multiple communities (shows select)', () => {
+    const wrapper = mount(SearchHero, {
+      props: { communities: multiCommunity },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe('BrowseStrip snapshot', () => {
+  it('renders with single community', () => {
+    const wrapper = mount(BrowseStrip, {
+      props: { communities: singleCommunity },
+      ...globalStubs,
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+```
+
+- [ ] **Step 2: Run snapshots to generate baselines**
+
+Run: `npm run test:js -- --run tests/js/snapshots.test.ts`
+Expected: 13 tests PASS. Vitest creates snapshot file at `tests/js/__snapshots__/snapshots.test.ts.snap`.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `npm run test:js`
+Expected: All tests pass (config tests + behavioral tests + snapshots).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/js/snapshots.test.ts tests/js/__snapshots__/
+git commit -m "test(#84): add DOM snapshot tests for all Vue components
+
+13 snapshots covering KnowledgeCard (5 type variants), CitationCard,
+AnswerPanel, SearchInput, TypeFilter (2 states), SearchHero (single +
+multi community), and BrowseStrip.
+
+Phase D.1 safeguard — lightweight DOM snapshots. Playwright screenshot
+diffs deferred to Phase D.3 when the design system stabilizes.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Run full JS test suite**
+
+Run: `npm run test:js`
+Expected: All tests pass.
+
+- [ ] **Step 2: Run PHP test suite**
+
+Run: `./vendor/bin/phpunit`
+Expected: 198/198 pass (no PHP changes, just confirming no regressions).
+
+- [ ] **Step 3: Type check**
+
+Run: `npx vue-tsc --noEmit`
+Expected: Clean exit.
+
+- [ ] **Step 4: Static analysis**
+
+Run: `./vendor/bin/phpstan analyse src/`
+Expected: Clean exit.

--- a/docs/superpowers/specs/2026-04-05-giiken-boot-to-browser-design.md
+++ b/docs/superpowers/specs/2026-04-05-giiken-boot-to-browser-design.md
@@ -31,7 +31,7 @@ This is the real source of the `200 empty body` response. PHP's built-in server 
 
 `entity-storage/SqlSchemaHandler::ensureTable()` (entity-storage/src/SqlSchemaHandler.php:31) can build tables from an `EntityType` spec, but nothing calls it automatically at boot. The framework's `Migrator` / `MigrationLoader` (foundation/src/Migration/) discovers migrations from `{basePath}/migrations/*.php` and from each package manifest, and `vendor/bin/waaseyaa migrate` already runs them. Giiken has no `migrations/` directory.
 
-### 4. `GiikenServiceProvider::register()` binds nothing
+### 4. `AppServiceProvider::register()` binds nothing
 
 The DI container is already available — the base `ServiceProvider` class exposes `singleton()` and `bind()` (foundation/src/ServiceProvider/ServiceProvider.php). The service provider just has a TODO block listing every service that needs wiring:
 
@@ -93,7 +93,7 @@ A `Waaseyaa\Foundation\Migration\Migration` whose `up()` iterates every register
 
 **Open question addressed at plan-writing time:** The framework's `Migration` load pattern loads files via `require` as plain factories. The migration will need access to `EntityTypeManager` + `SqlSchemaHandler` at `up()` time. If the framework has no clean pattern for this, PR A grows by one class: `Waaseyaa\Foundation\Migration\EntitySchemaMigration` base class that receives the manager/handler via `setContext()` from the `Migrator`. See Risk A.
 
-**2c. `GiikenServiceProvider::register()` — real service wiring.**
+**2c. `AppServiceProvider::register()` — real service wiring.**
 Replace the TODO block with bindings. Final interfaces confirmed while writing the plan; expected shape:
 
 ```php
@@ -106,26 +106,26 @@ $this->singleton(KnowledgeItemRepositoryInterface::class, fn () =>
 $this->singleton(SearchProviderInterface::class, fn () =>
     new Fts5SearchProvider($this->kernelResolver(DatabaseInterface::class)));
 
-$this->singleton(Giiken\Pipeline\Provider\EmbeddingProviderInterface::class, fn () =>
+$this->singleton(App\Pipeline\Provider\EmbeddingProviderInterface::class, fn () =>
     new FakeEmbeddingAdapter(new \Waaseyaa\AiVector\Testing\FakeEmbeddingProvider()));
 
-$this->singleton(Giiken\Pipeline\Provider\LlmProviderInterface::class, fn () =>
+$this->singleton(App\Pipeline\Provider\LlmProviderInterface::class, fn () =>
     new NullLlmAdapter(new \Waaseyaa\AiAgent\Provider\NullLlmProvider()));
 
 $this->singleton(SearchService::class, fn () => new SearchService(
     $this->resolve(SearchProviderInterface::class),
-    $this->resolve(Giiken\Pipeline\Provider\EmbeddingProviderInterface::class),
+    $this->resolve(App\Pipeline\Provider\EmbeddingProviderInterface::class),
     new KnowledgeItemAccessPolicy(),
     $this->resolve(KnowledgeItemRepositoryInterface::class),
 ));
 
 $this->singleton(QaServiceInterface::class, fn () => new QaService(
     $this->resolve(SearchService::class),
-    $this->resolve(Giiken\Pipeline\Provider\LlmProviderInterface::class),
+    $this->resolve(App\Pipeline\Provider\LlmProviderInterface::class),
 ));
 
 // ReportService, ExportService, ImportService follow the same pattern — their
-// constructor signatures are documented in src/GiikenServiceProvider.php's
+// constructor signatures are documented in src/AppServiceProvider.php's
 // existing Phase 3 TODO block and will be wired verbatim. Elided here for brevity.
 $this->singleton(ReportService::class, /* see TODO block */);
 $this->singleton(ExportService::class, /* see TODO block */);
@@ -137,10 +137,10 @@ Two tiny Giiken-local adapter classes in `src/Pipeline/Provider/Adapter/` bridge
 - `FakeEmbeddingAdapter` — wraps `\Waaseyaa\AiVector\Testing\FakeEmbeddingProvider`
 - `NullLlmAdapter` — wraps `\Waaseyaa\AiAgent\Provider\NullLlmProvider`
 
-Each is ~20 lines, real, not a stub. They exist because Giiken chose to define its own provider interfaces in `Giiken\Pipeline\Provider\` rather than depending on framework interfaces directly — the adapters are the bridge.
+Each is ~20 lines, real, not a stub. They exist because Giiken chose to define its own provider interfaces in `App\Pipeline\Provider\` rather than depending on framework interfaces directly — the adapters are the bridge.
 
 **2d. `src/Console/SeedTestCommunityCommand.php`.**
-A real Symfony console command (`giiken:seed:test-community`), registered via `GiikenServiceProvider::commands()`, that:
+A real Symfony console command (`giiken:seed:test-community`), registered via `AppServiceProvider::commands()`, that:
 
 - Builds a `Community` entity with `slug='test-community'`, `name='Test Community'`, a default `WikiSchema` (default_language='en', all five `KnowledgeType` cases enabled, default llm_instructions).
 - Saves via `CommunityRepository`.
@@ -197,7 +197,7 @@ packages/ai-agent/tests/Unit/Provider/NullLlmProviderTest.php (new)
 ```
 public/index.php                                                   (new, via make:public)
 migrations/001_ensure_entity_tables.php                            (new)
-src/GiikenServiceProvider.php                                      (modify: delete TODO block, add register bindings + commands())
+src/AppServiceProvider.php                                      (modify: delete TODO block, add register bindings + commands())
 src/Pipeline/Provider/Adapter/FakeEmbeddingAdapter.php             (new, ~20 lines)
 src/Pipeline/Provider/Adapter/NullLlmAdapter.php                   (new, ~20 lines)
 src/Console/SeedTestCommunityCommand.php                           (new)
@@ -223,7 +223,7 @@ All deferred items have GitHub issues filed so nothing is lost:
 
 **Risk A — `Migration` load pattern.** The framework loads migrations via `require` as plain factories. The migration in 2b needs `EntityTypeManager` and `SqlSchemaHandler` at `up()` time. If no clean pattern exists, PR A grows by one class: a `Waaseyaa\Foundation\Migration\EntitySchemaMigration` base that the `Migrator` injects context into before calling `up()`. Mitigation: verify the pattern during plan writing; if uncertain, split Giiken's migration into "raw SQL" (schemas hard-coded) as a safe fallback.
 
-**Risk B — Giiken vs framework provider interfaces.** `Giiken\Pipeline\Provider\EmbeddingProviderInterface` and `LlmProviderInterface` are Giiken-local interfaces, not the framework's. The adapter approach in 2c handles this cleanly, but it does mean the framework's `NullLlmProvider` cannot be bound directly — it's always wrapped. Accepted as a cost of Giiken owning its own interfaces.
+**Risk B — Giiken vs framework provider interfaces.** `App\Pipeline\Provider\EmbeddingProviderInterface` and `LlmProviderInterface` are Giiken-local interfaces, not the framework's. The adapter approach in 2c handles this cleanly, but it does mean the framework's `NullLlmProvider` cannot be bound directly — it's always wrapped. Accepted as a cost of Giiken owning its own interfaces.
 
 **Risk C — `Fts5SearchProvider` may not exist.** Investigation saw `SearchProviderInterface` referenced in Giiken's `SearchService` constructor but did not confirm a concrete `Fts5SearchProvider` class ships in `waaseyaa/search`. If the concrete class is missing, options:
 

--- a/docs/superpowers/specs/2026-04-05-phase3-query-layer-design.md
+++ b/docs/superpowers/specs/2026-04-05-phase3-query-layer-design.md
@@ -35,7 +35,7 @@ Provides hybrid full-text + semantic search over KnowledgeItems, scoped to a com
 #### Interface
 
 ```php
-namespace Giiken\Query;
+namespace App\Query;
 
 class SearchService
 {
@@ -117,7 +117,7 @@ RAG-based question answering grounded in a community's knowledge base.
 #### Interface
 
 ```php
-namespace Giiken\Query;
+namespace App\Query;
 
 class QaService
 {
@@ -164,7 +164,7 @@ class QaService
 #### Interfaces
 
 ```php
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
 interface ReportRendererInterface
 {
@@ -231,7 +231,7 @@ Produces a ZIP archive containing the community's full dataset in open, portable
 #### Interface
 
 ```php
-namespace Giiken\Export;
+namespace App\Export;
 
 class ExportService
 {
@@ -300,7 +300,7 @@ Handles the core round-trip: community config + knowledge items. Media files are
 #### Interface
 
 ```php
-namespace Giiken\Export;
+namespace App\Export;
 
 class ImportService
 {
@@ -378,7 +378,7 @@ Error handling: on failure, sets `transcription_status = 'failed'` with an error
 
 ## Service Provider Wiring
 
-`GiikenServiceProvider` additions:
+`AppServiceProvider` additions:
 
 ```php
 // Search indexing: index KnowledgeItems on save
@@ -441,7 +441,7 @@ $container->singleton(ImportService::class, /* ... */);
 |------|--------|
 | `src/Entity/KnowledgeItem/KnowledgeItem.php` | Implement `SearchIndexableInterface` |
 | `src/Entity/KnowledgeItem/KnowledgeItemRepository.php` | Index on save |
-| `src/GiikenServiceProvider.php` | Register new services and handlers |
+| `src/AppServiceProvider.php` | Register new services and handlers |
 
 ### Test Files
 

--- a/docs/superpowers/specs/2026-04-06-entity-repository-factory-design.md
+++ b/docs/superpowers/specs/2026-04-06-entity-repository-factory-design.md
@@ -26,7 +26,7 @@ No production code in the framework calls `new EntityRepository(...)` — only t
 1. Re-assemble all the dependencies inside its own service provider (DRY violation, duplicated plumbing across consumers), or
 2. Drop down to `EntityTypeManager::getStorage()` and bypass the repository layer entirely (losing events, validation, revisions).
 
-For giiken this is the immediate blocker on waaseyaa/giiken#42: `GiikenServiceProvider::register()` cannot cleanly bind `CommunityRepositoryInterface` or `KnowledgeItemRepositoryInterface` without first deciding how to construct the underlying `EntityRepositoryInterface`.
+For giiken this is the immediate blocker on waaseyaa/giiken#42: `AppServiceProvider::register()` cannot cleanly bind `CommunityRepositoryInterface` or `KnowledgeItemRepositoryInterface` without first deciding how to construct the underlying `EntityRepositoryInterface`.
 
 ## Approach
 
@@ -265,7 +265,7 @@ Add a section to `docs/specs/entity-system.md` titled "Wiring per-entity-type re
 - PR merges green into `waaseyaa/framework` main
 - Downstream probe from giiken returns a working repository via the factory without hand-assembling dependencies
 - waaseyaa/framework#1128 is closed
-- `GiikenServiceProvider::register()` can now cleanly bind `CommunityRepositoryInterface` and `KnowledgeItemRepositoryInterface` in a follow-up PR (#42), unblocking the boot-to-browser path
+- `AppServiceProvider::register()` can now cleanly bind `CommunityRepositoryInterface` and `KnowledgeItemRepositoryInterface` in a follow-up PR (#42), unblocking the boot-to-browser path
 
 ## Execution order
 

--- a/docs/superpowers/specs/2026-04-12-discovery-surface-design.md
+++ b/docs/superpowers/specs/2026-04-12-discovery-surface-design.md
@@ -1,0 +1,182 @@
+# Discovery Surface: Config Coverage, Snapshots, and Search Hero
+
+**Issues:** #86, #84, #18
+**Date:** 2026-04-12
+**Approach:** Single combined spec, one PR with per-issue commits
+
+---
+
+## 1. Config Coverage Test (#86)
+
+**File:** `tests/js/KnowledgeTypeConfig.test.ts`
+
+### Changes to `types.ts`
+
+Export a `KNOWLEDGE_TYPES` const array typed as `KnowledgeType[]`:
+
+```ts
+export const KNOWLEDGE_TYPES: KnowledgeType[] = [
+  'cultural', 'governance', 'land', 'relationship', 'event',
+] as const satisfies readonly KnowledgeType[]
+```
+
+This gives a runtime-iterable source of truth. The existing `KNOWLEDGE_TYPE_CONFIG: Record<KnowledgeType, ...>` already enforces compile-time completeness; the array enables runtime assertions.
+
+### Invariant 1: TS-side completeness
+
+Assert that every member of `KNOWLEDGE_TYPES` has a corresponding key in `KNOWLEDGE_TYPE_CONFIG`, and vice versa. Same length, same members, no extras.
+
+### Invariant 2: PHP-TS sync
+
+Read `src/Entity/KnowledgeItem/KnowledgeType.php` at test time, extract enum case values via regex (`case\s+\w+\s*=\s*'(\w+)'`), and assert every PHP case either:
+
+- Exists in the TS `KNOWLEDGE_TYPES` array, or
+- Is listed in an `EXPECTED_FUTURE` set (starts with `['synthesis']`)
+
+Additional guard: if a value in `EXPECTED_FUTURE` also appears in `KNOWLEDGE_TYPES`, the test fails. This forces cleanup of the set when a future type gets wired into the frontend.
+
+### Why both invariants
+
+The TS compiler catches missing keys in `KNOWLEDGE_TYPE_CONFIG` at build time, but cannot detect PHP-side additions. The PHP-TS sync invariant catches the case where someone adds a new `KnowledgeType` enum case in PHP but forgets to add it to the TypeScript union and config. Together they form a closed loop: PHP enum -> TS union -> config record -> test.
+
+---
+
+## 2. DOM Snapshot Tests (#84)
+
+**File:** `tests/js/snapshots.test.ts`
+**Strategy:** Vitest inline snapshots via `mount().html()` from Vue Test Utils. No new dependencies.
+
+### Phase D.1 coverage (this PR)
+
+| Component | Fixtures | Snapshot count |
+|-----------|----------|---------------|
+| KnowledgeCard | One per knowledge type | 5 |
+| CitationCard | One citation with type | 1 |
+| AnswerPanel | Answer with 2 citations | 1 |
+| SearchInput | Default state with community slug | 1 |
+| TypeFilter | No active filter + one active | 2 |
+| SearchHero (#18) | Single community + multi community | 2 |
+| BrowseStrip (#18) | Single community | 1 |
+
+**Total: ~13 snapshots**
+
+### Structure
+
+Single test file, grouped by `describe()` blocks per component. Snapshot tests are structural, not behavioral, so they live separately from the existing per-component behavioral tests (`KnowledgeCard.test.ts`, `CitationCard.test.ts`, `AnswerPanel.test.ts`).
+
+### Stubs
+
+`@inertiajs/vue3` `Link` stubbed as a plain `<a>` element (matches existing test pattern).
+
+### Phase D.3 (later, not this PR)
+
+- Introduce Playwright screenshot diffs
+- Capture baselines for key flows
+- Add CI gating
+
+### Cleanup
+
+Any Playwright-based tests found in `/tmp/giiken-puppeteer/` or elsewhere that are heavy/inappropriate for the current stage will be removed.
+
+---
+
+## 3. Discovery Surface (#18)
+
+**Scope:** Rework `Discover.vue` (the `/` root landing page). `Discovery/Index.vue` (community-scoped) is untouched.
+
+### New component: `SearchHero.vue`
+
+Full-width gradient hero section for the root landing page.
+
+**Props:**
+```ts
+defineProps<{
+  communities: CommunitySummary[]
+}>()
+```
+
+**Behavior:**
+- Gradient background using existing `from-primary to-primary-hover` tokens
+- Headline: "Sovereign Indigenous Knowledge"
+- Subtext: governance-focused tagline
+- Embedded `SearchInput` configured for root-level use
+- When `communities.length === 1`: search input navigates directly to that community's search/ask route
+- When `communities.length > 1`: a `<select>` element appears inline before the search input, listing community names. Selected community determines the search/ask navigation target.
+- When `communities.length === 0`: search input is hidden (nothing to search)
+
+**Styling:** Reuses existing design tokens. No new CSS custom properties needed.
+
+### New component: `BrowseStrip.vue`
+
+Horizontal knowledge-type chip strip below the hero.
+
+**Props:**
+```ts
+defineProps<{
+  communities: CommunitySummary[]
+}>()
+```
+
+**Behavior:**
+- Renders one chip per entry in `KNOWLEDGE_TYPE_CONFIG`
+- Uses `KNOWLEDGE_TYPE_CONFIG` for labels and chip styling (same tokens as `TypeFilter`)
+- Unlike `TypeFilter` (which filters an in-page list), `BrowseStrip` chips are navigation links
+- Each chip navigates to `/{communitySlug}?type={type}`
+- When multiple communities exist, chips link to the first community (MVP behavior)
+- When no communities exist, strip is hidden
+
+**Layout:** Horizontal scroll on mobile, centered row on desktop. `overflow-x-auto` with `flex-nowrap`.
+
+### Updated `Discover.vue` structure
+
+```html
+<div class="min-h-screen bg-surface">
+  <nav>  <!-- existing, unchanged -->
+  <SearchHero :communities="communities" />
+  <BrowseStrip :communities="communities" />
+  <main>  <!-- existing community grid, unchanged -->
+</div>
+```
+
+The hero replaces the current `<header>` block. The browse strip sits between hero and community grid as a new section. The community grid below remains as-is.
+
+### No backend changes
+
+The existing controller already passes `communities: CommunitySummary[]` to the Inertia page. All navigation targets (`/{slug}`, `/{slug}/search`, `/{slug}/ask`) already have routes and controllers.
+
+### Props flow
+
+- `Discover.vue` receives `communities: CommunitySummary[]` (unchanged)
+- Passes `communities` down to `SearchHero` and `BrowseStrip`
+- Both components derive navigation targets from community slugs
+
+---
+
+## File inventory
+
+### New files
+- `tests/js/KnowledgeTypeConfig.test.ts` — config coverage test
+- `tests/js/snapshots.test.ts` — DOM snapshot tests
+- `resources/js/Components/SearchHero.vue` — hero component
+- `resources/js/Components/BrowseStrip.vue` — browse strip component
+
+### Modified files
+- `resources/js/types.ts` — add `KNOWLEDGE_TYPES` array export
+- `resources/js/Pages/Discover.vue` — replace `<header>` with `SearchHero` + `BrowseStrip`
+
+### Unchanged files
+- `resources/js/Pages/Discovery/Index.vue`
+- `resources/js/Components/SearchInput.vue`
+- `resources/js/Components/TypeFilter.vue`
+- `resources/js/Components/KnowledgeCard.vue`
+- All PHP files
+
+---
+
+## Commit plan
+
+1. `feat(#86): add KNOWLEDGE_TYPES array and config coverage test`
+2. `feat(#18): add SearchHero and BrowseStrip components, rework Discover.vue`
+3. `test(#84): add DOM snapshot tests for all Vue components`
+
+Snapshots go last so they capture the final state of all components including the new #18 ones.

--- a/public/index.php
+++ b/public/index.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+if (PHP_SAPI === 'cli-server') {
+    $path = __DIR__ . parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+    if (is_file($path)) {
+        return false;
+    }
+}
+
 require __DIR__ . '/../vendor/autoload.php';
 
 $projectRoot = dirname(__DIR__);

--- a/resources/js/Components/BrowseStrip.vue
+++ b/resources/js/Components/BrowseStrip.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Link } from '@inertiajs/vue3'
+import { KNOWLEDGE_TYPE_CONFIG } from '@/types'
+import type { KnowledgeType, CommunitySummary } from '@/types'
+
+const props = defineProps<{
+  communities: CommunitySummary[]
+}>()
+
+const types = Object.entries(KNOWLEDGE_TYPE_CONFIG) as [KnowledgeType, typeof KNOWLEDGE_TYPE_CONFIG[KnowledgeType]][]
+const targetSlug = computed(() => props.communities[0]?.slug)
+</script>
+
+<template>
+  <section v-if="communities.length > 0" class="max-w-5xl mx-auto px-6 pt-8">
+    <div class="flex gap-2 overflow-x-auto flex-nowrap justify-center">
+      <Link
+        v-for="[type, config] in types"
+        :key="type"
+        :href="`/${targetSlug}?type=${type}`"
+        class="px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors"
+        :class="config.chip"
+      >
+        {{ config.label }}
+      </Link>
+    </div>
+  </section>
+</template>

--- a/resources/js/Components/SearchHero.vue
+++ b/resources/js/Components/SearchHero.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { router } from '@inertiajs/vue3'
+import type { CommunitySummary } from '@/types'
+
+const props = defineProps<{
+  communities: CommunitySummary[]
+}>()
+
+const query = ref('')
+const selectedSlug = computed(() => {
+  if (props.communities.length === 1) return props.communities[0].slug
+  return manualSlug.value
+})
+const manualSlug = ref(props.communities[0]?.slug ?? '')
+
+function submit() {
+  const q = query.value.trim()
+  if (!q || !selectedSlug.value) return
+
+  const isQuestion = q.includes('?') || q.split(/\s+/).length > 5
+  const route = isQuestion
+    ? `/${selectedSlug.value}/ask`
+    : `/${selectedSlug.value}/search`
+
+  router.get(route, { q, page: 1 })
+}
+</script>
+
+<template>
+  <header class="bg-gradient-to-br from-primary to-primary-hover text-on-primary py-20 px-6 text-center">
+    <h1 class="text-4xl font-bold mb-3">Sovereign Indigenous Knowledge</h1>
+    <p class="text-primary-subtle text-lg max-w-2xl mx-auto mb-10">
+      Browse community knowledge bases. Each community governs its own content under its own protocols.
+    </p>
+
+    <form
+      v-if="communities.length > 0"
+      class="flex items-center justify-center gap-2 max-w-2xl mx-auto"
+      @submit.prevent="submit"
+    >
+      <select
+        v-if="communities.length > 1"
+        v-model="manualSlug"
+        class="px-3 py-3 rounded-lg border border-border text-ink text-base"
+      >
+        <option v-for="c in communities" :key="c.id" :value="c.slug">
+          {{ c.name }}
+        </option>
+      </select>
+      <input
+        v-model="query"
+        type="text"
+        placeholder="Search or ask a question..."
+        class="flex-1 px-4 py-3 rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary text-ink text-base"
+      />
+      <button
+        type="submit"
+        class="px-6 py-3 bg-surface text-primary rounded-lg hover:bg-surface-raised font-medium"
+      >
+        Ask →
+      </button>
+    </form>
+  </header>
+</template>

--- a/resources/js/Pages/Discover.vue
+++ b/resources/js/Pages/Discover.vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
 import { Link } from '@inertiajs/vue3'
-
-interface CommunitySummary {
-  id: number | string
-  name: string
-  slug: string
-  locale: string
-}
+import SearchHero from '@/Components/SearchHero.vue'
+import BrowseStrip from '@/Components/BrowseStrip.vue'
+import type { CommunitySummary } from '@/types'
 
 defineProps<{
   communities: CommunitySummary[]
@@ -19,12 +15,8 @@ defineProps<{
       <span class="font-bold text-lg">Giiken</span>
     </nav>
 
-    <header class="bg-gradient-to-br from-primary to-primary-hover text-on-primary py-20 px-6 text-center">
-      <h1 class="text-4xl font-bold mb-3">Sovereign Indigenous Knowledge</h1>
-      <p class="text-primary-subtle text-lg max-w-2xl mx-auto">
-        Browse community knowledge bases. Each community governs its own content under its own protocols.
-      </p>
-    </header>
+    <SearchHero :communities="communities" />
+    <BrowseStrip :communities="communities" />
 
     <main class="max-w-5xl mx-auto px-6 py-12">
       <h2 class="text-xl font-semibold text-ink mb-6">Communities</h2>

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -14,6 +14,11 @@ export interface KnowledgeItem {
 }
 
 export type KnowledgeType = 'cultural' | 'governance' | 'land' | 'relationship' | 'event'
+
+export const KNOWLEDGE_TYPES = [
+  'cultural', 'governance', 'land', 'relationship', 'event',
+] as const satisfies readonly KnowledgeType[]
+
 export type AccessTier = 'public' | 'members' | 'staff' | 'restricted'
 export type CommunityRole = 'admin' | 'knowledge_keeper' | 'staff' | 'member' | 'public'
 

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -22,6 +22,13 @@ export const KNOWLEDGE_TYPES = [
 export type AccessTier = 'public' | 'members' | 'staff' | 'restricted'
 export type CommunityRole = 'admin' | 'knowledge_keeper' | 'staff' | 'member' | 'public'
 
+export interface CommunitySummary {
+  id: number | string
+  name: string
+  slug: string
+  locale: string
+}
+
 export interface Community {
   id: string
   name: string

--- a/scripts/check-lifecycle-drift.sh
+++ b/scripts/check-lifecycle-drift.sh
@@ -27,7 +27,7 @@ fi
 # Files that usually imply lifecycle behavior changes.
 WATCH_PATTERNS=(
   "^public/index\\.php$"
-  "^src/GiikenServiceProvider\\.php$"
+  "^src/Provider/AppServiceProvider\\.php$"
   "^src/Http/Controller/.*\\.php$"
   "^src/Http/Middleware/.*\\.php$"
   "^src/Entity/.*\\.php$"

--- a/src/Access/CommunityRole.php
+++ b/src/Access/CommunityRole.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Access;
+namespace App\Access;
 
 enum CommunityRole: string
 {

--- a/src/Access/KnowledgeItemAccessPolicy.php
+++ b/src/Access/KnowledgeItemAccessPolicy.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Access;
+namespace App\Access;
 
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 use Waaseyaa\Access\AccessPolicyInterface;
 use Waaseyaa\Access\AccessResult;
 use Waaseyaa\Access\AccountInterface;

--- a/src/Access/PublicIngestionPolicy.php
+++ b/src/Access/PublicIngestionPolicy.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Access;
+namespace App\Access;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 use Waaseyaa\Access\AccessPolicyInterface;
 use Waaseyaa\Access\AccessResult;
 use Waaseyaa\Access\AccountInterface;

--- a/src/Console/SeedTestCommunityCommand.php
+++ b/src/Console/SeedTestCommunityCommand.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Console;
+namespace App\Console;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\Community\WikiSchema;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\Community\WikiSchema;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\User\User;

--- a/src/Entity/Community/Community.php
+++ b/src/Entity/Community/Community.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Entity\Community;
+namespace App\Entity\Community;
 
 use Carbon\CarbonImmutable;
 use Waaseyaa\Entity\ContentEntityBase;

--- a/src/Entity/Community/CommunityRepository.php
+++ b/src/Entity/Community/CommunityRepository.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Entity\Community;
+namespace App\Entity\Community;
 
 use Carbon\CarbonImmutable;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;

--- a/src/Entity/Community/CommunityRepositoryInterface.php
+++ b/src/Entity/Community/CommunityRepositoryInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Entity\Community;
+namespace App\Entity\Community;
 
 interface CommunityRepositoryInterface
 {

--- a/src/Entity/Community/SovereigntyProfile.php
+++ b/src/Entity/Community/SovereigntyProfile.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Entity\Community;
+namespace App\Entity\Community;
 
 enum SovereigntyProfile: string
 {

--- a/src/Entity/Community/WikiSchema.php
+++ b/src/Entity/Community/WikiSchema.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Entity\Community;
+namespace App\Entity\Community;
 
 final class WikiSchema
 {

--- a/src/Entity/HasCommunity.php
+++ b/src/Entity/HasCommunity.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Entity;
+namespace App\Entity;
 
 interface HasCommunity
 {

--- a/src/Entity/KnowledgeItem/AccessTier.php
+++ b/src/Entity/KnowledgeItem/AccessTier.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Entity\KnowledgeItem;
+namespace App\Entity\KnowledgeItem;
 
 enum AccessTier: string
 {

--- a/src/Entity/KnowledgeItem/KnowledgeItem.php
+++ b/src/Entity/KnowledgeItem/KnowledgeItem.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Entity\KnowledgeItem;
+namespace App\Entity\KnowledgeItem;
 
 use Carbon\CarbonImmutable;
-use Giiken\Entity\HasCommunity;
+use App\Entity\HasCommunity;
 use Waaseyaa\Entity\ContentEntityBase;
 use Waaseyaa\Entity\Hydration\HydratableFromStorageInterface;
 use Waaseyaa\Entity\Hydration\HydrationContext;

--- a/src/Entity/KnowledgeItem/KnowledgeItemRepository.php
+++ b/src/Entity/KnowledgeItem/KnowledgeItemRepository.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Entity\KnowledgeItem;
+namespace App\Entity\KnowledgeItem;
 
 use Carbon\CarbonImmutable;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;

--- a/src/Entity/KnowledgeItem/KnowledgeItemRepositoryInterface.php
+++ b/src/Entity/KnowledgeItem/KnowledgeItemRepositoryInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Entity\KnowledgeItem;
+namespace App\Entity\KnowledgeItem;
 
 interface KnowledgeItemRepositoryInterface
 {

--- a/src/Entity/KnowledgeItem/KnowledgeType.php
+++ b/src/Entity/KnowledgeItem/KnowledgeType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Entity\KnowledgeItem;
+namespace App\Entity\KnowledgeItem;
 
 enum KnowledgeType: string
 {

--- a/src/Export/ExportService.php
+++ b/src/Export/ExportService.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Export;
+namespace App\Export;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
 use RuntimeException;
 use Waaseyaa\Access\AccountInterface;
 use ZipArchive;

--- a/src/Export/ExportServiceInterface.php
+++ b/src/Export/ExportServiceInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Export;
+namespace App\Export;
 
-use Giiken\Entity\Community\Community;
+use App\Entity\Community\Community;
 use Waaseyaa\Access\AccountInterface;
 
 interface ExportServiceInterface

--- a/src/Export/ImportResult.php
+++ b/src/Export/ImportResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Export;
+namespace App\Export;
 
 final readonly class ImportResult
 {

--- a/src/Export/ImportService.php
+++ b/src/Export/ImportService.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Export;
+namespace App\Export;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
 use RuntimeException;
 use Waaseyaa\Access\AccountInterface;
 use ZipArchive;

--- a/src/Export/ImportServiceInterface.php
+++ b/src/Export/ImportServiceInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Export;
+namespace App\Export;
 
 use Waaseyaa\Access\AccountInterface;
 

--- a/src/Http/Controller/DiscoveryController.php
+++ b/src/Http/Controller/DiscoveryController.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Http\Controller;
+namespace App\Http\Controller;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Http\Inertia\InertiaHttpResponder;
-use Giiken\Query\QaServiceInterface;
-use Giiken\Query\SearchQuery;
-use Giiken\Query\SearchResultSet;
-use Giiken\Query\SearchService;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Http\Inertia\InertiaHttpResponder;
+use App\Query\QaServiceInterface;
+use App\Query\SearchQuery;
+use App\Query\SearchResultSet;
+use App\Query\SearchService;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Access\AccountInterface;

--- a/src/Http/Controller/HomeController.php
+++ b/src/Http/Controller/HomeController.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Http\Controller;
+namespace App\Http\Controller;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Http\Inertia\InertiaHttpResponder;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Http\Inertia\InertiaHttpResponder;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;
 use Waaseyaa\Access\AccountInterface;

--- a/src/Http/Controller/ManagementController.php
+++ b/src/Http/Controller/ManagementController.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Http\Controller;
+namespace App\Http\Controller;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Export\ExportServiceInterface;
-use Giiken\Http\Inertia\InertiaHttpResponder;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\IngestionHandlerRegistry;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Export\ExportServiceInterface;
+use App\Http\Inertia\InertiaHttpResponder;
+use App\Ingestion\IngestionException;
+use App\Ingestion\IngestionHandlerRegistry;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;

--- a/src/Http/Controller/QueryApiController.php
+++ b/src/Http/Controller/QueryApiController.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Http\Controller;
+namespace App\Http\Controller;
 
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Query\QaServiceInterface;
-use Giiken\Query\Report\ReportRequest;
-use Giiken\Query\Report\ReportServiceInterface;
-use Giiken\Query\SynthesisService;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Query\QaServiceInterface;
+use App\Query\Report\ReportRequest;
+use App\Query\Report\ReportServiceInterface;
+use App\Query\SynthesisService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Http/Controller/WebLoginController.php
+++ b/src/Http/Controller/WebLoginController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Http\Controller;
+namespace App\Http\Controller;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;

--- a/src/Http/Controller/WebLogoutController.php
+++ b/src/Http/Controller/WebLogoutController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Http\Controller;
+namespace App\Http\Controller;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;

--- a/src/Http/Inertia/InertiaHttpResponder.php
+++ b/src/Http/Inertia/InertiaHttpResponder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Http\Inertia;
+namespace App\Http\Inertia;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;

--- a/src/Http/Middleware/RequireStaffRole.php
+++ b/src/Http/Middleware/RequireStaffRole.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Http\Middleware;
+namespace App\Http\Middleware;
 
-use Giiken\Access\CommunityRole;
+use App\Access\CommunityRole;
 use Waaseyaa\Access\AccountInterface;
 
 final class RequireStaffRole

--- a/src/Ingestion/Converter/ConversionException.php
+++ b/src/Ingestion/Converter/ConversionException.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Converter;
+namespace App\Ingestion\Converter;
 
 final class ConversionException extends \RuntimeException {}

--- a/src/Ingestion/Converter/FileConverterInterface.php
+++ b/src/Ingestion/Converter/FileConverterInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Converter;
+namespace App\Ingestion\Converter;
 
 interface FileConverterInterface
 {

--- a/src/Ingestion/Converter/MarkItDownConverter.php
+++ b/src/Ingestion/Converter/MarkItDownConverter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Converter;
+namespace App\Ingestion\Converter;
 
 final class MarkItDownConverter implements FileConverterInterface
 {

--- a/src/Ingestion/FileIngestionHandlerInterface.php
+++ b/src/Ingestion/FileIngestionHandlerInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion;
+namespace App\Ingestion;
 
-use Giiken\Entity\Community\Community;
+use App\Entity\Community\Community;
 
 interface FileIngestionHandlerInterface
 {

--- a/src/Ingestion/Handler/CsvIngestionHandler.php
+++ b/src/Ingestion/Handler/CsvIngestionHandler.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Handler;
+namespace App\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\RawDocument;
 use Waaseyaa\Media\File;
 use Waaseyaa\Media\FileRepositoryInterface;
 

--- a/src/Ingestion/Handler/DocumentIngestionHandler.php
+++ b/src/Ingestion/Handler/DocumentIngestionHandler.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Handler;
+namespace App\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\RawDocument;
 use Waaseyaa\Media\File;
 use Waaseyaa\Media\FileRepositoryInterface;
 

--- a/src/Ingestion/Handler/HtmlIngestionHandler.php
+++ b/src/Ingestion/Handler/HtmlIngestionHandler.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Handler;
+namespace App\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\RawDocument;
 use Waaseyaa\Media\File;
 use Waaseyaa\Media\FileRepositoryInterface;
 

--- a/src/Ingestion/Handler/MarkdownIngestionHandler.php
+++ b/src/Ingestion/Handler/MarkdownIngestionHandler.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Handler;
+namespace App\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\RawDocument;
 use Symfony\Component\Yaml\Yaml;
 use Waaseyaa\Media\File;
 use Waaseyaa\Media\FileRepositoryInterface;

--- a/src/Ingestion/Handler/MediaIngestionHandler.php
+++ b/src/Ingestion/Handler/MediaIngestionHandler.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Handler;
+namespace App\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\Job\TranscribeJob;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\Job\TranscribeJob;
+use App\Ingestion\RawDocument;
 use Waaseyaa\Media\File;
 use Waaseyaa\Media\FileRepositoryInterface;
 use Waaseyaa\Queue\QueueInterface;

--- a/src/Ingestion/IngestionException.php
+++ b/src/Ingestion/IngestionException.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion;
+namespace App\Ingestion;
 
 final class IngestionException extends \RuntimeException {}

--- a/src/Ingestion/IngestionHandlerRegistry.php
+++ b/src/Ingestion/IngestionHandlerRegistry.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion;
+namespace App\Ingestion;
 
-use Giiken\Entity\Community\Community;
+use App\Entity\Community\Community;
 
 final class IngestionHandlerRegistry
 {

--- a/src/Ingestion/Job/TranscribeJob.php
+++ b/src/Ingestion/Job/TranscribeJob.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion\Job;
+namespace App\Ingestion\Job;
 
 use Waaseyaa\Queue\Job;
 

--- a/src/Ingestion/RawDocument.php
+++ b/src/Ingestion/RawDocument.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Ingestion;
+namespace App\Ingestion;
 
 final readonly class RawDocument
 {

--- a/src/Pipeline/CompilationPayload.php
+++ b/src/Pipeline/CompilationPayload.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline;
+namespace App\Pipeline;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Entity\KnowledgeItem\KnowledgeType;
 
 final class CompilationPayload
 {

--- a/src/Pipeline/CompilationPipeline.php
+++ b/src/Pipeline/CompilationPipeline.php
@@ -1,15 +1,15 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Pipeline;
+namespace App\Pipeline;
 
-use Giiken\Ingestion\RawDocument;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
-use Giiken\Pipeline\Step\ClassifyStep;
-use Giiken\Pipeline\Step\EmbedStep;
-use Giiken\Pipeline\Step\LinkStep;
-use Giiken\Pipeline\Step\StructureStep;
-use Giiken\Pipeline\Step\TranscribeStep;
+use App\Ingestion\RawDocument;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\Step\ClassifyStep;
+use App\Pipeline\Step\EmbedStep;
+use App\Pipeline\Step\LinkStep;
+use App\Pipeline\Step\StructureStep;
+use App\Pipeline\Step\TranscribeStep;
 use Waaseyaa\AI\Pipeline\PipelineContext;
 use Waaseyaa\AI\Pipeline\PipelineStepInterface;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;

--- a/src/Pipeline/PipelineException.php
+++ b/src/Pipeline/PipelineException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline;
+namespace App\Pipeline;
 
 final class PipelineException extends \RuntimeException
 {

--- a/src/Pipeline/Provider/EmbeddingProviderInterface.php
+++ b/src/Pipeline/Provider/EmbeddingProviderInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Provider;
+namespace App\Pipeline\Provider;
 
 interface EmbeddingProviderInterface
 {

--- a/src/Pipeline/Provider/LlmProviderInterface.php
+++ b/src/Pipeline/Provider/LlmProviderInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Provider;
+namespace App\Pipeline\Provider;
 
 interface LlmProviderInterface
 {

--- a/src/Pipeline/Provider/NullEmbeddingProvider.php
+++ b/src/Pipeline/Provider/NullEmbeddingProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Provider;
+namespace App\Pipeline\Provider;
 
 /**
  * Dev-friendly embedding + semantic search no-op (vector search returns no hits).

--- a/src/Pipeline/Provider/NullLlmProvider.php
+++ b/src/Pipeline/Provider/NullLlmProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline\Provider;
+namespace App\Pipeline\Provider;
 
 /**
  * Safe default LLM for local dev when no API keys or Ollama are configured.

--- a/src/Pipeline/SovereigntyConfig.php
+++ b/src/Pipeline/SovereigntyConfig.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Pipeline;
+namespace App\Pipeline;
 
 final class SovereigntyConfig
 {

--- a/src/Pipeline/Step/ClassifyStep.php
+++ b/src/Pipeline/Step/ClassifyStep.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Pipeline\Step;
+namespace App\Pipeline\Step;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\PipelineException;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\PipelineException;
+use App\Pipeline\Provider\LlmProviderInterface;
 use Waaseyaa\AI\Pipeline\PipelineContext;
 use Waaseyaa\AI\Pipeline\PipelineStepInterface;
 use Waaseyaa\AI\Pipeline\StepResult;

--- a/src/Pipeline/Step/EmbedStep.php
+++ b/src/Pipeline/Step/EmbedStep.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Pipeline\Step;
+namespace App\Pipeline\Step;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
 use Waaseyaa\AI\Pipeline\PipelineContext;
 use Waaseyaa\AI\Pipeline\PipelineStepInterface;
 use Waaseyaa\AI\Pipeline\StepResult;

--- a/src/Pipeline/Step/LinkStep.php
+++ b/src/Pipeline/Step/LinkStep.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Pipeline\Step;
+namespace App\Pipeline\Step;
 
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
 use Waaseyaa\AI\Pipeline\PipelineContext;
 use Waaseyaa\AI\Pipeline\PipelineStepInterface;
 use Waaseyaa\AI\Pipeline\StepResult;

--- a/src/Pipeline/Step/StructureStep.php
+++ b/src/Pipeline/Step/StructureStep.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Pipeline\Step;
+namespace App\Pipeline\Step;
 
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\PipelineException;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\PipelineException;
+use App\Pipeline\Provider\LlmProviderInterface;
 use Waaseyaa\AI\Pipeline\PipelineContext;
 use Waaseyaa\AI\Pipeline\PipelineStepInterface;
 use Waaseyaa\AI\Pipeline\StepResult;

--- a/src/Pipeline/Step/TranscribeStep.php
+++ b/src/Pipeline/Step/TranscribeStep.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Pipeline\Step;
+namespace App\Pipeline\Step;
 
 use Waaseyaa\AI\Pipeline\PipelineContext;
 use Waaseyaa\AI\Pipeline\PipelineStepInterface;

--- a/src/Provider/AppServiceProvider.php
+++ b/src/Provider/AppServiceProvider.php
@@ -2,47 +2,47 @@
 
 declare(strict_types=1);
 
-namespace Giiken;
+namespace App\Provider;
 
-use Giiken\Access\KnowledgeItemAccessPolicy;
-use Giiken\Console\SeedTestCommunityCommand;
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepository;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepository;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Export\ExportService;
-use Giiken\Export\ExportServiceInterface;
-use Giiken\Http\Controller\DiscoveryController;
-use Giiken\Http\Controller\HomeController;
-use Giiken\Http\Controller\ManagementController;
-use Giiken\Http\Controller\QueryApiController;
-use Giiken\Http\Controller\WebLoginController;
-use Giiken\Http\Controller\WebLogoutController;
-use Giiken\Http\Inertia\InertiaHttpResponder;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\Converter\MarkItDownConverter;
-use Giiken\Ingestion\Handler\CsvIngestionHandler;
-use Giiken\Ingestion\Handler\DocumentIngestionHandler;
-use Giiken\Ingestion\Handler\HtmlIngestionHandler;
-use Giiken\Ingestion\Handler\MarkdownIngestionHandler;
-use Giiken\Ingestion\Handler\MediaIngestionHandler;
-use Giiken\Ingestion\IngestionHandlerRegistry;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
-use Giiken\Pipeline\Provider\NullEmbeddingProvider;
-use Giiken\Pipeline\Provider\NullLlmProvider;
-use Giiken\Query\QaService;
-use Giiken\Query\QaServiceInterface;
-use Giiken\Query\Report\GovernanceSummaryReport;
-use Giiken\Query\Report\LandBriefReport;
-use Giiken\Query\Report\LanguageReport;
-use Giiken\Query\Report\ReportService;
-use Giiken\Query\Report\ReportServiceInterface;
-use Giiken\Query\SearchService;
-use Giiken\Query\SynthesisService;
-use Giiken\Wiki\WikiLintReport;
+use App\Access\KnowledgeItemAccessPolicy;
+use App\Console\SeedTestCommunityCommand;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepository;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepository;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Export\ExportService;
+use App\Export\ExportServiceInterface;
+use App\Http\Controller\DiscoveryController;
+use App\Http\Controller\HomeController;
+use App\Http\Controller\ManagementController;
+use App\Http\Controller\QueryApiController;
+use App\Http\Controller\WebLoginController;
+use App\Http\Controller\WebLogoutController;
+use App\Http\Inertia\InertiaHttpResponder;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\Converter\MarkItDownConverter;
+use App\Ingestion\Handler\CsvIngestionHandler;
+use App\Ingestion\Handler\DocumentIngestionHandler;
+use App\Ingestion\Handler\HtmlIngestionHandler;
+use App\Ingestion\Handler\MarkdownIngestionHandler;
+use App\Ingestion\Handler\MediaIngestionHandler;
+use App\Ingestion\IngestionHandlerRegistry;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\Provider\NullEmbeddingProvider;
+use App\Pipeline\Provider\NullLlmProvider;
+use App\Query\QaService;
+use App\Query\QaServiceInterface;
+use App\Query\Report\GovernanceSummaryReport;
+use App\Query\Report\LandBriefReport;
+use App\Query\Report\LanguageReport;
+use App\Query\Report\ReportService;
+use App\Query\Report\ReportServiceInterface;
+use App\Query\SearchService;
+use App\Query\SynthesisService;
+use App\Wiki\WikiLintReport;
 use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherContract;
 use Waaseyaa\Database\DatabaseInterface;
@@ -65,7 +65,7 @@ use Waaseyaa\Routing\WaaseyaaRouter;
 use Waaseyaa\Search\SearchIndexerInterface;
 use Waaseyaa\Search\SearchProviderInterface;
 
-final class GiikenServiceProvider extends ServiceProvider
+final class AppServiceProvider extends ServiceProvider
 {
     /**
      * Single-segment paths that must not be treated as community slugs (framework routes, APIs, auth).

--- a/src/Query/QaCitation.php
+++ b/src/Query/QaCitation.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
 final readonly class QaCitation
 {

--- a/src/Query/QaResponse.php
+++ b/src/Query/QaResponse.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
 final readonly class QaResponse
 {

--- a/src/Query/QaService.php
+++ b/src/Query/QaService.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
-use Giiken\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\Provider\LlmProviderInterface;
 use Waaseyaa\Access\AccountInterface;
 
 final class QaService implements QaServiceInterface

--- a/src/Query/QaServiceInterface.php
+++ b/src/Query/QaServiceInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
 use Waaseyaa\Access\AccountInterface;
 

--- a/src/Query/Report/DateRange.php
+++ b/src/Query/Report/DateRange.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
 final readonly class DateRange
 {

--- a/src/Query/Report/GovernanceSummaryReport.php
+++ b/src/Query/Report/GovernanceSummaryReport.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 final class GovernanceSummaryReport implements ReportRendererInterface
 {

--- a/src/Query/Report/LandBriefReport.php
+++ b/src/Query/Report/LandBriefReport.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 final class LandBriefReport implements ReportRendererInterface
 {

--- a/src/Query/Report/LanguageReport.php
+++ b/src/Query/Report/LanguageReport.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 final class LanguageReport implements ReportRendererInterface
 {

--- a/src/Query/Report/ReportRendererInterface.php
+++ b/src/Query/Report/ReportRendererInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 interface ReportRendererInterface
 {

--- a/src/Query/Report/ReportRequest.php
+++ b/src/Query/Report/ReportRequest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
 /**
  * @param string[] $knowledgeTypeValues Empty = use each report type's default filter only.

--- a/src/Query/Report/ReportResult.php
+++ b/src/Query/Report/ReportResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
 final readonly class ReportResult
 {

--- a/src/Query/Report/ReportService.php
+++ b/src/Query/Report/ReportService.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
-use Giiken\Access\CommunityRole;
-use Giiken\Access\KnowledgeItemAccessPolicy;
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Access\CommunityRole;
+use App\Access\KnowledgeItemAccessPolicy;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
 use Waaseyaa\Access\AccountInterface;
 
 final class ReportService implements ReportServiceInterface

--- a/src/Query/Report/ReportServiceInterface.php
+++ b/src/Query/Report/ReportServiceInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query\Report;
+namespace App\Query\Report;
 
-use Giiken\Entity\Community\Community;
+use App\Entity\Community\Community;
 use Waaseyaa\Access\AccountInterface;
 
 interface ReportServiceInterface

--- a/src/Query/SearchQuery.php
+++ b/src/Query/SearchQuery.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
 final readonly class SearchQuery
 {

--- a/src/Query/SearchResultItem.php
+++ b/src/Query/SearchResultItem.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Entity\KnowledgeItem\KnowledgeType;
 
 final readonly class SearchResultItem
 {

--- a/src/Query/SearchResultSet.php
+++ b/src/Query/SearchResultSet.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
 final readonly class SearchResultSet
 {

--- a/src/Query/SearchService.php
+++ b/src/Query/SearchService.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
-use Giiken\Access\KnowledgeItemAccessPolicy;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Access\KnowledgeItemAccessPolicy;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Search\SearchFilters;
 use Waaseyaa\Search\SearchProviderInterface;

--- a/src/Query/SynthesisAccessCapper.php
+++ b/src/Query/SynthesisAccessCapper.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 /**
  * Derives access metadata for a synthesis item from cited knowledge items.

--- a/src/Query/SynthesisService.php
+++ b/src/Query/SynthesisService.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Query;
+namespace App\Query;
 
-use Giiken\Access\KnowledgeItemAccessPolicy;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Access\KnowledgeItemAccessPolicy;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
 use InvalidArgumentException;
 use RuntimeException;
 use Waaseyaa\Access\AccountInterface;

--- a/src/Wiki/Check/BrokenLinkCheck.php
+++ b/src/Wiki/Check/BrokenLinkCheck.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Wiki\Check;
+namespace App\Wiki\Check;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 final class BrokenLinkCheck implements LintCheckInterface
 {

--- a/src/Wiki/Check/LintCheckInterface.php
+++ b/src/Wiki/Check/LintCheckInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Wiki\Check;
+namespace App\Wiki\Check;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 interface LintCheckInterface
 {

--- a/src/Wiki/Check/OrphanPageCheck.php
+++ b/src/Wiki/Check/OrphanPageCheck.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Wiki\Check;
+namespace App\Wiki\Check;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 
 final class OrphanPageCheck implements LintCheckInterface
 {

--- a/src/Wiki/WikiLintJob.php
+++ b/src/Wiki/WikiLintJob.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Wiki;
+namespace App\Wiki;
 
-use Giiken\Wiki\Check\LintCheckInterface;
+use App\Wiki\Check\LintCheckInterface;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
 
 final class WikiLintJob
@@ -20,7 +20,7 @@ final class WikiLintJob
 
     public function handle(): void
     {
-        /** @var list<\Giiken\Entity\KnowledgeItem\KnowledgeItem> $items */
+        /** @var list<\App\Entity\KnowledgeItem\KnowledgeItem> $items */
         $items = $this->repository->findBy([
             'community_id' => $this->communityId,
         ]);

--- a/src/Wiki/WikiLintReport.php
+++ b/src/Wiki/WikiLintReport.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Wiki;
+namespace App\Wiki;
 
 use Carbon\CarbonImmutable;
 use Waaseyaa\Entity\ContentEntityBase;

--- a/tests/Integration/Entity/ContentEntitySqlIntegrationTest.php
+++ b/tests/Integration/Entity/ContentEntitySqlIntegrationTest.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Integration\Entity;
+namespace App\Tests\Integration\Entity;
 
 use Carbon\CarbonImmutable;
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\SovereigntyProfile;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Tests\Integration\Support\GiikenKernelIntegrationTestCase;
-use Giiken\Wiki\WikiLintReport;
+use App\Entity\Community\Community;
+use App\Entity\Community\SovereigntyProfile;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Tests\Integration\Support\AppKernelIntegrationTestCase;
+use App\Wiki\WikiLintReport;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Uid\Uuid;
@@ -22,7 +22,7 @@ use Waaseyaa\Entity\Hydration\HydrationContext;
 use Waaseyaa\EntityStorage\Hydration\EntityInstantiator;
 
 #[CoversNothing]
-final class ContentEntitySqlIntegrationTest extends GiikenKernelIntegrationTestCase
+final class ContentEntitySqlIntegrationTest extends AppKernelIntegrationTestCase
 {
     #[Test]
     public function community_row_hydrates_via_repository_instantiator_and_casts(): void

--- a/tests/Integration/Http/AskPageTest.php
+++ b/tests/Integration/Http/AskPageTest.php
@@ -2,24 +2,24 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Integration\Http;
+namespace App\Tests\Integration\Http;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\Community\WikiSchema;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\GiikenServiceProvider;
-use Giiken\Tests\Integration\Support\GiikenKernelIntegrationTestCase;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\Community\WikiSchema;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Provider\AppServiceProvider;
+use App\Tests\Integration\Support\AppKernelIntegrationTestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Uid\Uuid;
 
 #[CoversNothing]
-final class AskPageTest extends GiikenKernelIntegrationTestCase
+final class AskPageTest extends AppKernelIntegrationTestCase
 {
     private static bool $seeded = false;
 
@@ -31,7 +31,7 @@ final class AskPageTest extends GiikenKernelIntegrationTestCase
             return;
         }
 
-        /** @var GiikenServiceProvider $giiken */
+        /** @var AppServiceProvider $giiken */
         $giiken = self::giikenProvider();
 
         /** @var CommunityRepositoryInterface $communityRepo */

--- a/tests/Integration/Http/DiscoverPageTest.php
+++ b/tests/Integration/Http/DiscoverPageTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Integration\Http;
+namespace App\Tests\Integration\Http;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Integration/Http/SearchPageTest.php
+++ b/tests/Integration/Http/SearchPageTest.php
@@ -2,24 +2,24 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Integration\Http;
+namespace App\Tests\Integration\Http;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\Community\WikiSchema;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\GiikenServiceProvider;
-use Giiken\Tests\Integration\Support\GiikenKernelIntegrationTestCase;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\Community\WikiSchema;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Provider\AppServiceProvider;
+use App\Tests\Integration\Support\AppKernelIntegrationTestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Uid\Uuid;
 
 #[CoversNothing]
-final class SearchPageTest extends GiikenKernelIntegrationTestCase
+final class SearchPageTest extends AppKernelIntegrationTestCase
 {
     private static bool $seeded = false;
 
@@ -31,7 +31,7 @@ final class SearchPageTest extends GiikenKernelIntegrationTestCase
             return;
         }
 
-        /** @var GiikenServiceProvider $giiken */
+        /** @var AppServiceProvider $giiken */
         $giiken = self::giikenProvider();
 
         /** @var CommunityRepositoryInterface $communityRepo */

--- a/tests/Integration/Support/AppKernelIntegrationTestCase.php
+++ b/tests/Integration/Support/AppKernelIntegrationTestCase.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Integration\Support;
+namespace App\Tests\Integration\Support;
 
-use Giiken\GiikenServiceProvider;
+use App\Provider\AppServiceProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 use Waaseyaa\Database\DatabaseInterface;
@@ -20,7 +20,7 @@ use Waaseyaa\Foundation\Kernel\HttpKernel;
 /**
  * Boots the real app kernel against :memory SQLite, runs pending migrations, and exposes helpers.
  */
-abstract class GiikenKernelIntegrationTestCase extends TestCase
+abstract class AppKernelIntegrationTestCase extends TestCase
 {
     private static string $projectRoot;
     private static HttpKernel $kernel;
@@ -69,15 +69,15 @@ abstract class GiikenKernelIntegrationTestCase extends TestCase
         return self::$kernel;
     }
 
-    protected static function giikenProvider(): GiikenServiceProvider
+    protected static function giikenProvider(): AppServiceProvider
     {
         foreach (self::kernel()->getProviders() as $provider) {
-            if ($provider instanceof GiikenServiceProvider) {
+            if ($provider instanceof AppServiceProvider) {
                 return $provider;
             }
         }
 
-        self::fail('GiikenServiceProvider not registered');
+        self::fail('AppServiceProvider not registered');
     }
 
     protected static function entityTypeManager(): EntityTypeManager

--- a/tests/Unit/Access/KnowledgeItemAccessPolicyTest.php
+++ b/tests/Unit/Access/KnowledgeItemAccessPolicyTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Access;
+namespace App\Tests\Unit\Access;
 
-use Giiken\Access\KnowledgeItemAccessPolicy;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Access\KnowledgeItemAccessPolicy;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Unit/Access/PublicIngestionPolicyTest.php
+++ b/tests/Unit/Access/PublicIngestionPolicyTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Access;
+namespace App\Tests\Unit\Access;
 
-use Giiken\Access\PublicIngestionPolicy;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Access\PublicIngestionPolicy;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Entity/Community/CommunityTest.php
+++ b/tests/Unit/Entity/Community/CommunityTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Entity\Community;
+namespace App\Tests\Unit\Entity\Community;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\WikiSchema;
-use Giiken\Entity\Community\SovereigntyProfile;
+use App\Entity\Community\Community;
+use App\Entity\Community\WikiSchema;
+use App\Entity\Community\SovereigntyProfile;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Entity/Community/CommunityWikiSchemaTest.php
+++ b/tests/Unit/Entity/Community/CommunityWikiSchemaTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Entity\Community;
+namespace App\Tests\Unit\Entity\Community;
 
-use Giiken\Entity\Community\Community;
+use App\Entity\Community\Community;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Entity/Community/WikiSchemaTest.php
+++ b/tests/Unit/Entity/Community/WikiSchemaTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Entity\Community;
+namespace App\Tests\Unit\Entity\Community;
 
-use Giiken\Entity\Community\WikiSchema;
+use App\Entity\Community\WikiSchema;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Entity/KnowledgeItem/KnowledgeItemSearchIndexableTest.php
+++ b/tests/Unit/Entity/KnowledgeItem/KnowledgeItemSearchIndexableTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Entity\KnowledgeItem;
+namespace App\Tests\Unit\Entity\KnowledgeItem;
 
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Entity/KnowledgeItem/KnowledgeItemTest.php
+++ b/tests/Unit/Entity/KnowledgeItem/KnowledgeItemTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Entity\KnowledgeItem;
+namespace App\Tests\Unit\Entity\KnowledgeItem;
 
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Waaseyaa\Entity\Hydration\HydrationContext;
 use PHPUnit\Framework\Attributes\Test;
@@ -108,7 +108,7 @@ final class KnowledgeItemTest extends TestCase
     public function it_implements_has_community(): void
     {
         $this->assertContains(
-            \Giiken\Entity\HasCommunity::class,
+            \App\Entity\HasCommunity::class,
             class_implements(KnowledgeItem::class) ?: [],
         );
     }

--- a/tests/Unit/Entity/KnowledgeItem/KnowledgeItemToMarkdownTest.php
+++ b/tests/Unit/Entity/KnowledgeItem/KnowledgeItemToMarkdownTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Entity\KnowledgeItem;
+namespace App\Tests\Unit\Entity\KnowledgeItem;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItem;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Export/ExportServiceTest.php
+++ b/tests/Unit/Export/ExportServiceTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Export;
+namespace App\Tests\Unit\Export;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Export\ExportService;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Export\ExportService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/Export/ImportServiceTest.php
+++ b/tests/Unit/Export/ImportServiceTest.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Export;
+namespace App\Tests\Unit\Export;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Export\ExportService;
-use Giiken\Export\ImportResult;
-use Giiken\Export\ImportService;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Export\ExportService;
+use App\Export\ImportResult;
+use App\Export\ImportService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/Http/Controller/DiscoveryControllerTest.php
+++ b/tests/Unit/Http/Controller/DiscoveryControllerTest.php
@@ -2,21 +2,21 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Http\Controller;
+namespace App\Tests\Unit\Http\Controller;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Http\Controller\DiscoveryController;
-use Giiken\Http\Inertia\InertiaHttpResponder;
-use Giiken\Query\QaResponse;
-use Giiken\Query\QaServiceInterface;
-use Giiken\Query\SearchQuery;
-use Giiken\Query\SearchResultItem;
-use Giiken\Query\SearchResultSet;
-use Giiken\Query\SearchService;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Http\Controller\DiscoveryController;
+use App\Http\Inertia\InertiaHttpResponder;
+use App\Query\QaResponse;
+use App\Query\QaServiceInterface;
+use App\Query\SearchQuery;
+use App\Query\SearchResultItem;
+use App\Query\SearchResultSet;
+use App\Query\SearchService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/Http/Controller/ManagementControllerTest.php
+++ b/tests/Unit/Http/Controller/ManagementControllerTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Http\Controller;
+namespace App\Tests\Unit\Http\Controller;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Http\Controller\ManagementController;
-use Giiken\Http\Inertia\InertiaHttpResponder;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Http\Controller\ManagementController;
+use App\Http\Inertia\InertiaHttpResponder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/Http/Controller/ManagementIngestUploadTest.php
+++ b/tests/Unit/Http/Controller/ManagementIngestUploadTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Http\Controller;
+namespace App\Tests\Unit\Http\Controller;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\Community\CommunityRepositoryInterface;
-use Giiken\Http\Controller\ManagementController;
-use Giiken\Http\Inertia\InertiaHttpResponder;
-use Giiken\Ingestion\Handler\MediaIngestionHandler;
-use Giiken\Ingestion\IngestionHandlerRegistry;
-use Giiken\Ingestion\Job\TranscribeJob;
+use App\Entity\Community\Community;
+use App\Entity\Community\CommunityRepositoryInterface;
+use App\Http\Controller\ManagementController;
+use App\Http\Inertia\InertiaHttpResponder;
+use App\Ingestion\Handler\MediaIngestionHandler;
+use App\Ingestion\IngestionHandlerRegistry;
+use App\Ingestion\Job\TranscribeJob;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Http/Middleware/RequireStaffRoleTest.php
+++ b/tests/Unit/Http/Middleware/RequireStaffRoleTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Http\Middleware;
+namespace App\Tests\Unit\Http\Middleware;
 
-use Giiken\Http\Middleware\RequireStaffRole;
+use App\Http\Middleware\RequireStaffRole;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Ingestion/Converter/MarkItDownConverterTest.php
+++ b/tests/Unit/Ingestion/Converter/MarkItDownConverterTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Converter;
+namespace App\Tests\Unit\Ingestion\Converter;
 
-use Giiken\Ingestion\Converter\ConversionException;
-use Giiken\Ingestion\Converter\MarkItDownConverter;
+use App\Ingestion\Converter\ConversionException;
+use App\Ingestion\Converter\MarkItDownConverter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Ingestion/Handler/CsvIngestionHandlerTest.php
+++ b/tests/Unit/Ingestion/Handler/CsvIngestionHandlerTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Handler;
+namespace App\Tests\Unit\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\Handler\CsvIngestionHandler;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\Handler\CsvIngestionHandler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Ingestion/Handler/DocumentIngestionHandlerTest.php
+++ b/tests/Unit/Ingestion/Handler/DocumentIngestionHandlerTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Handler;
+namespace App\Tests\Unit\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\Handler\DocumentIngestionHandler;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\Handler\DocumentIngestionHandler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Ingestion/Handler/HtmlIngestionHandlerTest.php
+++ b/tests/Unit/Ingestion/Handler/HtmlIngestionHandlerTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Handler;
+namespace App\Tests\Unit\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Converter\FileConverterInterface;
-use Giiken\Ingestion\Handler\HtmlIngestionHandler;
+use App\Entity\Community\Community;
+use App\Ingestion\Converter\FileConverterInterface;
+use App\Ingestion\Handler\HtmlIngestionHandler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Ingestion/Handler/MarkdownIngestionHandlerTest.php
+++ b/tests/Unit/Ingestion/Handler/MarkdownIngestionHandlerTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Handler;
+namespace App\Tests\Unit\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Handler\MarkdownIngestionHandler;
+use App\Entity\Community\Community;
+use App\Ingestion\Handler\MarkdownIngestionHandler;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Ingestion/Handler/MediaIngestionHandlerTest.php
+++ b/tests/Unit/Ingestion/Handler/MediaIngestionHandlerTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Handler;
+namespace App\Tests\Unit\Ingestion\Handler;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\Handler\MediaIngestionHandler;
-use Giiken\Ingestion\IngestionException;
+use App\Entity\Community\Community;
+use App\Ingestion\Handler\MediaIngestionHandler;
+use App\Ingestion\IngestionException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Unit/Ingestion/IngestionHandlerRegistryTest.php
+++ b/tests/Unit/Ingestion/IngestionHandlerRegistryTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion;
+namespace App\Tests\Unit\Ingestion;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Ingestion\FileIngestionHandlerInterface;
-use Giiken\Ingestion\IngestionException;
-use Giiken\Ingestion\IngestionHandlerRegistry;
-use Giiken\Ingestion\RawDocument;
+use App\Entity\Community\Community;
+use App\Ingestion\FileIngestionHandlerInterface;
+use App\Ingestion\IngestionException;
+use App\Ingestion\IngestionHandlerRegistry;
+use App\Ingestion\RawDocument;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Ingestion/Job/TranscribeJobTest.php
+++ b/tests/Unit/Ingestion/Job/TranscribeJobTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Ingestion\Job;
+namespace App\Tests\Unit\Ingestion\Job;
 
-use Giiken\Ingestion\Job\TranscribeJob;
+use App\Ingestion\Job\TranscribeJob;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Pipeline/CompilationPipelineTest.php
+++ b/tests/Unit/Pipeline/CompilationPipelineTest.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Tests\Unit\Pipeline;
+namespace App\Tests\Unit\Pipeline;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Ingestion\RawDocument;
-use Giiken\Pipeline\CompilationPipeline;
-use Giiken\Pipeline\PipelineException;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Ingestion\RawDocument;
+use App\Pipeline\CompilationPipeline;
+use App\Pipeline\PipelineException;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Provider\LlmProviderInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Pipeline/Step/ClassifyStepTest.php
+++ b/tests/Unit/Pipeline/Step/ClassifyStepTest.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Tests\Unit\Pipeline\Step;
+namespace App\Tests\Unit\Pipeline\Step;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\PipelineException;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
-use Giiken\Pipeline\Step\ClassifyStep;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\PipelineException;
+use App\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\Step\ClassifyStep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Pipeline/Step/EmbedStepTest.php
+++ b/tests/Unit/Pipeline/Step/EmbedStepTest.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Tests\Unit\Pipeline\Step;
+namespace App\Tests\Unit\Pipeline\Step;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Pipeline\Step\EmbedStep;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Step\EmbedStep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Pipeline/Step/LinkStepTest.php
+++ b/tests/Unit/Pipeline/Step/LinkStepTest.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Tests\Unit\Pipeline\Step;
+namespace App\Tests\Unit\Pipeline\Step;
 
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Pipeline\Step\LinkStep;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Pipeline\Step\LinkStep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Pipeline/Step/StructureStepTest.php
+++ b/tests/Unit/Pipeline/Step/StructureStepTest.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Tests\Unit\Pipeline\Step;
+namespace App\Tests\Unit\Pipeline\Step;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\PipelineException;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
-use Giiken\Pipeline\Step\StructureStep;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\PipelineException;
+use App\Pipeline\Provider\LlmProviderInterface;
+use App\Pipeline\Step\StructureStep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Pipeline/Step/TranscribeStepTest.php
+++ b/tests/Unit/Pipeline/Step/TranscribeStepTest.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace Giiken\Tests\Unit\Pipeline\Step;
+namespace App\Tests\Unit\Pipeline\Step;
 
-use Giiken\Pipeline\CompilationPayload;
-use Giiken\Pipeline\Step\TranscribeStep;
+use App\Pipeline\CompilationPayload;
+use App\Pipeline\Step\TranscribeStep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Provider/AppServiceProviderTest.php
+++ b/tests/Unit/Provider/AppServiceProviderTest.php
@@ -2,34 +2,34 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit;
+namespace App\Tests\Unit\Provider;
 
-use Giiken\GiikenServiceProvider;
+use App\Provider\AppServiceProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 
-#[CoversClass(GiikenServiceProvider::class)]
-final class GiikenServiceProviderTest extends TestCase
+#[CoversClass(AppServiceProvider::class)]
+final class AppServiceProviderTest extends TestCase
 {
     #[Test]
     public function it_extends_service_provider(): void
     {
         $this->assertTrue(
-            is_subclass_of(GiikenServiceProvider::class, ServiceProvider::class),
+            is_subclass_of(AppServiceProvider::class, ServiceProvider::class),
         );
     }
 
     #[Test]
     public function register_is_callable(): void
     {
-        $this->assertTrue(method_exists(GiikenServiceProvider::class, 'register'));
+        $this->assertTrue(method_exists(AppServiceProvider::class, 'register'));
     }
 
     #[Test]
     public function routes_is_callable(): void
     {
-        $this->assertTrue(method_exists(GiikenServiceProvider::class, 'routes'));
+        $this->assertTrue(method_exists(AppServiceProvider::class, 'routes'));
     }
 }

--- a/tests/Unit/Query/QaServiceTest.php
+++ b/tests/Unit/Query/QaServiceTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query;
+namespace App\Tests\Unit\Query;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Pipeline\Provider\LlmProviderInterface;
-use Giiken\Query\QaService;
-use Giiken\Query\SearchResultItem;
-use Giiken\Query\SearchResultSet;
-use Giiken\Query\SearchService;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Pipeline\Provider\LlmProviderInterface;
+use App\Query\QaService;
+use App\Query\SearchResultItem;
+use App\Query\SearchResultSet;
+use App\Query\SearchService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/Query/Report/DateRangeTest.php
+++ b/tests/Unit/Query/Report/DateRangeTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query\Report;
+namespace App\Tests\Unit\Query\Report;
 
-use Giiken\Query\Report\DateRange;
+use App\Query\Report\DateRange;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Query/Report/GovernanceSummaryReportTest.php
+++ b/tests/Unit/Query/Report/GovernanceSummaryReportTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query\Report;
+namespace App\Tests\Unit\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Query\Report\DateRange;
-use Giiken\Query\Report\GovernanceSummaryReport;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Query\Report\DateRange;
+use App\Query\Report\GovernanceSummaryReport;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Query/Report/LandBriefReportTest.php
+++ b/tests/Unit/Query/Report/LandBriefReportTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query\Report;
+namespace App\Tests\Unit\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Query\Report\DateRange;
-use Giiken\Query\Report\LandBriefReport;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Query\Report\DateRange;
+use App\Query\Report\LandBriefReport;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Query/Report/LanguageReportTest.php
+++ b/tests/Unit/Query/Report/LanguageReportTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query\Report;
+namespace App\Tests\Unit\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Query\Report\DateRange;
-use Giiken\Query\Report\LanguageReport;
+use App\Entity\Community\Community;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Query\Report\DateRange;
+use App\Query\Report\LanguageReport;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Query/Report/ReportServiceTest.php
+++ b/tests/Unit/Query/Report/ReportServiceTest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query\Report;
+namespace App\Tests\Unit\Query\Report;
 
-use Giiken\Entity\Community\Community;
-use Giiken\Access\KnowledgeItemAccessPolicy;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Query\Report\DateRange;
-use Giiken\Query\Report\GovernanceSummaryReport;
-use Giiken\Query\Report\LandBriefReport;
-use Giiken\Query\Report\LanguageReport;
-use Giiken\Query\Report\ReportService;
+use App\Entity\Community\Community;
+use App\Access\KnowledgeItemAccessPolicy;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Query\Report\DateRange;
+use App\Query\Report\GovernanceSummaryReport;
+use App\Query\Report\LandBriefReport;
+use App\Query\Report\LanguageReport;
+use App\Query\Report\ReportService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/Query/SearchQueryTest.php
+++ b/tests/Unit/Query/SearchQueryTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query;
+namespace App\Tests\Unit\Query;
 
-use Giiken\Query\SearchQuery;
+use App\Query\SearchQuery;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Query/SearchResultSetTest.php
+++ b/tests/Unit/Query/SearchResultSetTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query;
+namespace App\Tests\Unit\Query;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Query\SearchResultItem;
-use Giiken\Query\SearchResultSet;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Query\SearchResultItem;
+use App\Query\SearchResultSet;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Query/SearchServiceTest.php
+++ b/tests/Unit/Query/SearchServiceTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query;
+namespace App\Tests\Unit\Query;
 
-use Giiken\Access\KnowledgeItemAccessPolicy;
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
-use Giiken\Pipeline\Provider\EmbeddingProviderInterface;
-use Giiken\Query\SearchQuery;
-use Giiken\Query\SearchService;
+use App\Access\KnowledgeItemAccessPolicy;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeItemRepositoryInterface;
+use App\Pipeline\Provider\EmbeddingProviderInterface;
+use App\Query\SearchQuery;
+use App\Query\SearchService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/Query/SynthesisAccessCapperTest.php
+++ b/tests/Unit/Query/SynthesisAccessCapperTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Query;
+namespace App\Tests\Unit\Query;
 
-use Giiken\Entity\KnowledgeItem\AccessTier;
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Entity\KnowledgeItem\KnowledgeType;
-use Giiken\Query\SynthesisAccessCapper;
+use App\Entity\KnowledgeItem\AccessTier;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Entity\KnowledgeItem\KnowledgeType;
+use App\Query\SynthesisAccessCapper;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Wiki/Check/BrokenLinkCheckTest.php
+++ b/tests/Unit/Wiki/Check/BrokenLinkCheckTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Wiki\Check;
+namespace App\Tests\Unit\Wiki\Check;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Wiki\Check\BrokenLinkCheck;
-use Giiken\Wiki\Check\LintCheckInterface;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Wiki\Check\BrokenLinkCheck;
+use App\Wiki\Check\LintCheckInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Wiki/Check/OrphanPageCheckTest.php
+++ b/tests/Unit/Wiki/Check/OrphanPageCheckTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Wiki\Check;
+namespace App\Tests\Unit\Wiki\Check;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Wiki\Check\LintCheckInterface;
-use Giiken\Wiki\Check\OrphanPageCheck;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Wiki\Check\LintCheckInterface;
+use App\Wiki\Check\OrphanPageCheck;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Wiki/WikiLintJobTest.php
+++ b/tests/Unit/Wiki/WikiLintJobTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Giiken\Tests\Unit\Wiki;
+namespace App\Tests\Unit\Wiki;
 
-use Giiken\Entity\KnowledgeItem\KnowledgeItem;
-use Giiken\Wiki\Check\BrokenLinkCheck;
-use Giiken\Wiki\Check\LintCheckInterface;
-use Giiken\Wiki\Check\OrphanPageCheck;
-use Giiken\Wiki\WikiLintJob;
-use Giiken\Wiki\WikiLintReport;
+use App\Entity\KnowledgeItem\KnowledgeItem;
+use App\Wiki\Check\BrokenLinkCheck;
+use App\Wiki\Check\LintCheckInterface;
+use App\Wiki\Check\OrphanPageCheck;
+use App\Wiki\WikiLintJob;
+use App\Wiki\WikiLintReport;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;

--- a/tests/js/KnowledgeTypeConfig.test.ts
+++ b/tests/js/KnowledgeTypeConfig.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { KNOWLEDGE_TYPES, KNOWLEDGE_TYPE_CONFIG } from '@/types'
+
+describe('KNOWLEDGE_TYPE_CONFIG', () => {
+  it('has an entry for every member of KNOWLEDGE_TYPES', () => {
+    const configKeys = Object.keys(KNOWLEDGE_TYPE_CONFIG).sort()
+    const typesList = [...KNOWLEDGE_TYPES].sort()
+    expect(configKeys).toEqual(typesList)
+  })
+
+  it('every config entry has required style properties', () => {
+    for (const type of KNOWLEDGE_TYPES) {
+      const entry = KNOWLEDGE_TYPE_CONFIG[type]
+      expect(entry).toHaveProperty('label')
+      expect(entry).toHaveProperty('chip')
+      expect(entry).toHaveProperty('activeChip')
+      expect(entry).toHaveProperty('dot')
+    }
+  })
+
+  const EXPECTED_FUTURE = new Set(['synthesis'])
+
+  it('every PHP KnowledgeType case is in KNOWLEDGE_TYPES or EXPECTED_FUTURE', async () => {
+    const fs = await import('node:fs/promises')
+    const path = await import('node:path')
+    const phpPath = path.resolve(__dirname, '../../src/Entity/KnowledgeItem/KnowledgeType.php')
+    const phpSource = await fs.readFile(phpPath, 'utf-8')
+    const caseRegex = /case\s+\w+\s*=\s*'(\w+)'/g
+    const phpCases: string[] = []
+    let match: RegExpExecArray | null
+    while ((match = caseRegex.exec(phpSource)) !== null) {
+      phpCases.push(match[1])
+    }
+
+    expect(phpCases.length).toBeGreaterThan(0)
+
+    const tsSet = new Set<string>(KNOWLEDGE_TYPES)
+    for (const phpCase of phpCases) {
+      const inTs = tsSet.has(phpCase)
+      const inFuture = EXPECTED_FUTURE.has(phpCase)
+      expect(
+        inTs || inFuture,
+        `PHP case '${phpCase}' is not in KNOWLEDGE_TYPES or EXPECTED_FUTURE`,
+      ).toBe(true)
+    }
+  })
+
+  it('EXPECTED_FUTURE has no members already in KNOWLEDGE_TYPES', () => {
+    const tsSet = new Set<string>(KNOWLEDGE_TYPES)
+    for (const futureType of EXPECTED_FUTURE) {
+      expect(
+        tsSet.has(futureType),
+        `'${futureType}' is in both EXPECTED_FUTURE and KNOWLEDGE_TYPES — remove it from EXPECTED_FUTURE`,
+      ).toBe(false)
+    }
+  })
+})

--- a/tests/js/__snapshots__/snapshots.test.ts.snap
+++ b/tests/js/__snapshots__/snapshots.test.ts.snap
@@ -1,0 +1,120 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AnswerPanel snapshot > renders an answer with citations 1`] = `
+"<div class="bg-surface-raised rounded-lg border border-border p-6">
+  <div class="flex items-center gap-2 mb-4"><span class="w-2.5 h-2.5 bg-primary rounded-full"></span><span class="font-semibold text-ink">Answer</span><span class="text-xs text-ink-muted">from your knowledge base</span></div>
+  <div>
+    <p class="text-ink whitespace-pre-line leading-relaxed">This is the answer <sup class="mx-0.5"><a href="#citation-1" class="text-primary font-semibold no-underline hover:underline">[1]</a></sup> with sources <sup class="mx-0.5"><a href="#citation-2" class="text-primary font-semibold no-underline hover:underline">[2]</a></sup>.</p>
+    <div class="mt-6 pt-4 border-t border-border">
+      <p class="text-sm font-medium text-ink-muted mb-2">Sources</p>
+      <div class="space-y-2">
+        <div id="citation-1" class="border border-border rounded bg-surface overflow-hidden"><button type="button" class="w-full flex items-start gap-2 text-left p-3 hover:bg-surface-raised transition-colors" aria-expanded="false" aria-controls="citation-1-body"><span class="text-primary font-medium shrink-0">[1]</span><span class="font-medium text-ink flex-1 min-w-0 truncate">Doc A</span><span class="text-xs px-2 py-0.5 rounded-full shrink-0 bg-cultural-subtle text-cultural">Cultural</span><span class="text-xs text-ink-muted shrink-0">+</span></button>
+          <!--v-if-->
+        </div>
+        <div id="citation-2" class="border border-border rounded bg-surface overflow-hidden"><button type="button" class="w-full flex items-start gap-2 text-left p-3 hover:bg-surface-raised transition-colors" aria-expanded="false" aria-controls="citation-2-body"><span class="text-primary font-medium shrink-0">[2]</span><span class="font-medium text-ink flex-1 min-w-0 truncate">Doc B</span><span class="text-xs px-2 py-0.5 rounded-full shrink-0 bg-land-subtle text-land">Land</span><span class="text-xs text-ink-muted shrink-0">+</span></button>
+          <!--v-if-->
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`BrowseStrip snapshot > renders with single community 1`] = `
+"<section class="max-w-5xl mx-auto px-6 pt-8">
+  <div class="flex gap-2 overflow-x-auto flex-nowrap justify-center"><a href="/test-nation?type=cultural" class="px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors bg-cultural-subtle text-cultural">Cultural</a><a href="/test-nation?type=governance" class="px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors bg-governance-subtle text-governance">Governance</a><a href="/test-nation?type=land" class="px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors bg-land-subtle text-land">Land</a><a href="/test-nation?type=relationship" class="px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors bg-relationship-subtle text-relationship">Relationship</a><a href="/test-nation?type=event" class="px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors bg-event-subtle text-event">Event</a></div>
+</section>"
+`;
+
+exports[`CitationCard snapshot > renders a citation 1`] = `
+"<div id="citation-1" class="border border-border rounded bg-surface overflow-hidden"><button type="button" class="w-full flex items-start gap-2 text-left p-3 hover:bg-surface-raised transition-colors" aria-expanded="false" aria-controls="citation-1-body"><span class="text-primary font-medium shrink-0">[1]</span><span class="font-medium text-ink flex-1 min-w-0 truncate">Governance doc</span><span class="text-xs px-2 py-0.5 rounded-full shrink-0 bg-governance-subtle text-governance">Governance</span><span class="text-xs text-ink-muted shrink-0">+</span></button>
+  <!--v-if-->
+</div>"
+`;
+
+exports[`KnowledgeCard snapshots > renders cultural variant 1`] = `
+"<a href="/test-community/item/1" class="block p-4 bg-surface-raised rounded-lg border border-border hover:shadow-md transition-shadow">
+  <div class="flex items-start gap-3">
+    <div class="w-3 h-3 rounded-full mt-1.5 shrink-0 bg-cultural"></div>
+    <div class="min-w-0">
+      <h3 class="font-semibold text-ink truncate">cultural item</h3>
+      <p class="text-sm text-ink-muted mt-1 line-clamp-2">A cultural knowledge item.</p><span class="inline-block text-xs px-2 py-0.5 rounded-full mt-2 bg-cultural-subtle text-cultural">Cultural</span>
+    </div>
+  </div>
+</a>"
+`;
+
+exports[`KnowledgeCard snapshots > renders event variant 1`] = `
+"<a href="/test-community/item/1" class="block p-4 bg-surface-raised rounded-lg border border-border hover:shadow-md transition-shadow">
+  <div class="flex items-start gap-3">
+    <div class="w-3 h-3 rounded-full mt-1.5 shrink-0 bg-event"></div>
+    <div class="min-w-0">
+      <h3 class="font-semibold text-ink truncate">event item</h3>
+      <p class="text-sm text-ink-muted mt-1 line-clamp-2">A event knowledge item.</p><span class="inline-block text-xs px-2 py-0.5 rounded-full mt-2 bg-event-subtle text-event">Event</span>
+    </div>
+  </div>
+</a>"
+`;
+
+exports[`KnowledgeCard snapshots > renders governance variant 1`] = `
+"<a href="/test-community/item/1" class="block p-4 bg-surface-raised rounded-lg border border-border hover:shadow-md transition-shadow">
+  <div class="flex items-start gap-3">
+    <div class="w-3 h-3 rounded-full mt-1.5 shrink-0 bg-governance"></div>
+    <div class="min-w-0">
+      <h3 class="font-semibold text-ink truncate">governance item</h3>
+      <p class="text-sm text-ink-muted mt-1 line-clamp-2">A governance knowledge item.</p><span class="inline-block text-xs px-2 py-0.5 rounded-full mt-2 bg-governance-subtle text-governance">Governance</span>
+    </div>
+  </div>
+</a>"
+`;
+
+exports[`KnowledgeCard snapshots > renders land variant 1`] = `
+"<a href="/test-community/item/1" class="block p-4 bg-surface-raised rounded-lg border border-border hover:shadow-md transition-shadow">
+  <div class="flex items-start gap-3">
+    <div class="w-3 h-3 rounded-full mt-1.5 shrink-0 bg-land"></div>
+    <div class="min-w-0">
+      <h3 class="font-semibold text-ink truncate">land item</h3>
+      <p class="text-sm text-ink-muted mt-1 line-clamp-2">A land knowledge item.</p><span class="inline-block text-xs px-2 py-0.5 rounded-full mt-2 bg-land-subtle text-land">Land</span>
+    </div>
+  </div>
+</a>"
+`;
+
+exports[`KnowledgeCard snapshots > renders relationship variant 1`] = `
+"<a href="/test-community/item/1" class="block p-4 bg-surface-raised rounded-lg border border-border hover:shadow-md transition-shadow">
+  <div class="flex items-start gap-3">
+    <div class="w-3 h-3 rounded-full mt-1.5 shrink-0 bg-relationship"></div>
+    <div class="min-w-0">
+      <h3 class="font-semibold text-ink truncate">relationship item</h3>
+      <p class="text-sm text-ink-muted mt-1 line-clamp-2">A relationship knowledge item.</p><span class="inline-block text-xs px-2 py-0.5 rounded-full mt-2 bg-relationship-subtle text-relationship">Relationship</span>
+    </div>
+  </div>
+</a>"
+`;
+
+exports[`SearchHero snapshots > renders with multiple communities (shows select) 1`] = `
+"<header class="bg-gradient-to-br from-primary to-primary-hover text-on-primary py-20 px-6 text-center">
+  <h1 class="text-4xl font-bold mb-3">Sovereign Indigenous Knowledge</h1>
+  <p class="text-primary-subtle text-lg max-w-2xl mx-auto mb-10"> Browse community knowledge bases. Each community governs its own content under its own protocols. </p>
+  <form class="flex items-center justify-center gap-2 max-w-2xl mx-auto"><select class="px-3 py-3 rounded-lg border border-border text-ink text-base">
+      <option value="test-nation">Test Nation</option>
+      <option value="second-nation">Second Nation</option>
+    </select><input type="text" placeholder="Search or ask a question..." class="flex-1 px-4 py-3 rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary text-ink text-base"><button type="submit" class="px-6 py-3 bg-surface text-primary rounded-lg hover:bg-surface-raised font-medium"> Ask → </button></form>
+</header>"
+`;
+
+exports[`SearchHero snapshots > renders with single community (no select) 1`] = `
+"<header class="bg-gradient-to-br from-primary to-primary-hover text-on-primary py-20 px-6 text-center">
+  <h1 class="text-4xl font-bold mb-3">Sovereign Indigenous Knowledge</h1>
+  <p class="text-primary-subtle text-lg max-w-2xl mx-auto mb-10"> Browse community knowledge bases. Each community governs its own content under its own protocols. </p>
+  <form class="flex items-center justify-center gap-2 max-w-2xl mx-auto">
+    <!--v-if--><input type="text" placeholder="Search or ask a question..." class="flex-1 px-4 py-3 rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary text-ink text-base"><button type="submit" class="px-6 py-3 bg-surface text-primary rounded-lg hover:bg-surface-raised font-medium"> Ask → </button>
+  </form>
+</header>"
+`;
+
+exports[`SearchInput snapshot > renders default state 1`] = `"<form class="flex gap-2 w-full max-w-2xl"><input type="text" placeholder="Search or ask a question..." class="flex-1 px-4 py-3 rounded-lg border border-border focus:outline-none focus:ring-2 focus:ring-primary text-base"><button type="submit" class="px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover font-medium"> Ask → </button></form>"`;
+
+exports[`TypeFilter snapshots > renders with cultural active 1`] = `"<div class="flex gap-2 flex-wrap"><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-primary-subtle text-primary"> All </button><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-cultural text-on-primary">Cultural</button><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-governance-subtle text-governance">Governance</button><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-land-subtle text-land">Land</button><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-relationship-subtle text-relationship">Relationship</button><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-event-subtle text-event">Event</button></div>"`;
+
+exports[`TypeFilter snapshots > renders with no active filter 1`] = `"<div class="flex gap-2 flex-wrap"><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-primary text-on-primary"> All </button><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-cultural-subtle text-cultural">Cultural</button><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-governance-subtle text-governance">Governance</button><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-land-subtle text-land">Land</button><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-relationship-subtle text-relationship">Relationship</button><button class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors bg-event-subtle text-event">Event</button></div>"`;

--- a/tests/js/snapshots.test.ts
+++ b/tests/js/snapshots.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import KnowledgeCard from '@/Components/KnowledgeCard.vue'
+import CitationCard from '@/Components/CitationCard.vue'
+import AnswerPanel from '@/Components/AnswerPanel.vue'
+import SearchInput from '@/Components/SearchInput.vue'
+import TypeFilter from '@/Components/TypeFilter.vue'
+import SearchHero from '@/Components/SearchHero.vue'
+import BrowseStrip from '@/Components/BrowseStrip.vue'
+import { KNOWLEDGE_TYPES } from '@/types'
+import type { KnowledgeType, Citation, CommunitySummary } from '@/types'
+
+const LinkStub = { template: '<a :href="href"><slot /></a>', props: ['href'] }
+
+const singleCommunity: CommunitySummary[] = [{ id: '1', name: 'Test Nation', slug: 'test-nation', locale: 'en' }]
+const multiCommunity: CommunitySummary[] = [
+  { id: '1', name: 'Test Nation', slug: 'test-nation', locale: 'en' },
+  { id: '2', name: 'Second Nation', slug: 'second-nation', locale: 'fr' },
+]
+
+describe('KnowledgeCard snapshots', () => {
+  for (const type of KNOWLEDGE_TYPES) {
+    it(`renders ${type} variant`, () => {
+      const wrapper = mount(KnowledgeCard, {
+        props: {
+          id: '1',
+          title: `${type} item`,
+          summary: `A ${type} knowledge item.`,
+          knowledgeType: type as KnowledgeType,
+          communitySlug: 'test-community',
+        },
+        global: { stubs: { Link: LinkStub } },
+      })
+      expect(wrapper.html()).toMatchSnapshot()
+    })
+  }
+})
+
+describe('CitationCard snapshot', () => {
+  it('renders a citation', () => {
+    const citation: Citation = {
+      itemId: '10',
+      title: 'Governance doc',
+      excerpt: 'Relevant excerpt from the document.',
+      knowledgeType: 'governance',
+    }
+    const wrapper = mount(CitationCard, {
+      props: { index: 1, citation, communitySlug: 'test-community' },
+      global: { stubs: { Link: LinkStub } },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe('AnswerPanel snapshot', () => {
+  it('renders an answer with citations', () => {
+    const citations: Citation[] = [
+      { itemId: '10', title: 'Doc A', excerpt: 'Excerpt A.', knowledgeType: 'cultural' },
+      { itemId: '11', title: 'Doc B', excerpt: 'Excerpt B.', knowledgeType: 'land' },
+    ]
+    const wrapper = mount(AnswerPanel, {
+      props: {
+        answer: 'This is the answer [1] with sources [2].',
+        citations,
+        communitySlug: 'test-community',
+      },
+      global: { stubs: { Link: LinkStub } },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe('SearchInput snapshot', () => {
+  it('renders default state', () => {
+    const wrapper = mount(SearchInput, {
+      props: { communitySlug: 'test-community' },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe('TypeFilter snapshots', () => {
+  it('renders with no active filter', () => {
+    const wrapper = mount(TypeFilter, {
+      props: { active: null },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders with cultural active', () => {
+    const wrapper = mount(TypeFilter, {
+      props: { active: 'cultural' as KnowledgeType },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe('SearchHero snapshots', () => {
+  it('renders with single community (no select)', () => {
+    const wrapper = mount(SearchHero, {
+      props: { communities: singleCommunity },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders with multiple communities (shows select)', () => {
+    const wrapper = mount(SearchHero, {
+      props: { communities: multiCommunity },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe('BrowseStrip snapshot', () => {
+  it('renders with single community', () => {
+    const wrapper = mount(BrowseStrip, {
+      props: { communities: singleCommunity },
+      global: { stubs: { Link: LinkStub } },
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
## Summary

- Renamed `Giiken\` namespace to `App\` across all 126 PHP files (src + tests)
- Moved `GiikenServiceProvider` → `src/Provider/AppServiceProvider.php`
- Renamed `GiikenKernelIntegrationTestCase` → `AppKernelIntegrationTestCase`
- Updated `composer.json` PSR-4 autoload and `extra.waaseyaa.providers`
- Updated lifecycle drift script, CLAUDE.md, and all design docs

## Test plan

- [x] PHPUnit: 218 tests, 652 assertions passing
- [x] Vitest: 36 tests passing
- [x] Lifecycle drift hook passing
- [x] Zero remaining `Giiken\` references in codebase

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)