### PR TITLE
fix(#93): align Ask page citation indices with Sources list

### DIFF
--- a/resources/js/Components/AnswerPanel.vue
+++ b/resources/js/Components/AnswerPanel.vue
@@ -98,10 +98,17 @@ const shouldRenderNoAnswer = computed(
       <div v-if="citations.length > 0" class="mt-6 pt-4 border-t border-border">
         <p class="text-sm font-medium text-ink-muted mb-2">Sources</p>
         <div class="space-y-2">
+          <!--
+            `index` must match the token the LLM emits in the answer body
+            (`QaService` uses the DB item id there). Using `idx + 1` broke
+            alignment whenever the LLM did not cite item #1 (giiken#93):
+            a body `[2]` pointed at Sources card `#citation-1` after the
+            list was trimmed to only-cited-items.
+          -->
           <CitationCard
-            v-for="(citation, idx) in citations"
+            v-for="citation in citations"
             :key="citation.itemId"
-            :index="idx + 1"
+            :index="citation.itemId"
             :citation="citation"
             :community-slug="communitySlug"
           />

--- a/resources/js/Components/CitationCard.vue
+++ b/resources/js/Components/CitationCard.vue
@@ -5,7 +5,11 @@ import { KNOWLEDGE_TYPE_CONFIG } from '@/types'
 import type { Citation } from '@/types'
 
 const props = defineProps<{
-  index: number
+  // Citation token used for both the visible `[N]` label and the
+  // `#citation-N` anchor id. Must match the token the LLM emits in the
+  // answer text (see QaService::SYSTEM_PROMPT — currently the DB item id).
+  // See giiken#93 for the original mismatch bug.
+  index: number | string
   citation: Citation
   communitySlug: string
 }>()

--- a/tests/js/AnswerPanel.test.ts
+++ b/tests/js/AnswerPanel.test.ts
@@ -13,7 +13,11 @@ function mountPanel(overrides: Partial<{
 }> = {}) {
   return mount(AnswerPanel, {
     props: {
-      answer: 'Governance is described here [1] and also here [2].',
+      // LLM cites by DB item id (see QaService::SYSTEM_PROMPT). The Sources
+      // card must reuse that same id for both the `[N]` label and the
+      // `#citation-N` anchor — otherwise `[42]` in the answer would point
+      // at `#citation-1` after the trimmed list was renumbered (giiken#93).
+      answer: 'Governance is described here [42] and also here [43].',
       citations: [
         { itemId: '42', title: 'Governance overview', excerpt: 'A sample governance note.', knowledgeType: 'governance' },
         { itemId: '43', title: 'Land rights', excerpt: 'A sample land reference.', knowledgeType: 'land' },
@@ -36,10 +40,24 @@ describe('AnswerPanel', () => {
     const wrapper = mountPanel()
     const sups = wrapper.findAll('sup')
     expect(sups).toHaveLength(2)
-    expect(sups[0].text()).toBe('[1]')
-    expect(sups[1].text()).toBe('[2]')
-    expect(sups[0].find('a').attributes('href')).toBe('#citation-1')
-    expect(sups[1].find('a').attributes('href')).toBe('#citation-2')
+    expect(sups[0].text()).toBe('[42]')
+    expect(sups[1].text()).toBe('[43]')
+    expect(sups[0].find('a').attributes('href')).toBe('#citation-42')
+    expect(sups[1].find('a').attributes('href')).toBe('#citation-43')
+  })
+
+  it('uses the citation itemId for Sources labels and anchors so inline [N] aligns (giiken#93)', () => {
+    const wrapper = mountPanel()
+    // Anchors in the answer body.
+    const hrefs = wrapper.findAll('sup a').map((a) => a.attributes('href'))
+    expect(hrefs).toEqual(['#citation-42', '#citation-43'])
+    // Matching anchor ids in the Sources card.
+    expect(wrapper.find('#citation-42').exists()).toBe(true)
+    expect(wrapper.find('#citation-43').exists()).toBe(true)
+    // And the visible label in the Sources card matches, not a renumbered [1][2].
+    const sourcesText = wrapper.text()
+    expect(sourcesText).toContain('[42]')
+    expect(sourcesText).toContain('[43]')
   })
 
   it('preserves the answer prose between superscripts', () => {
@@ -60,9 +78,9 @@ describe('AnswerPanel', () => {
     const wrapper = mountPanel()
     expect(wrapper.text()).toContain('Governance overview')
     expect(wrapper.text()).toContain('Land rights')
-    // Cards have anchor ids so superscript links resolve.
-    expect(wrapper.find('#citation-1').exists()).toBe(true)
-    expect(wrapper.find('#citation-2').exists()).toBe(true)
+    // Cards have anchor ids matching the answer's `[N]` markers.
+    expect(wrapper.find('#citation-42').exists()).toBe(true)
+    expect(wrapper.find('#citation-43').exists()).toBe(true)
   })
 
   it('shows a skeleton placeholder while loading and hides answer text', () => {

--- a/tests/js/__snapshots__/snapshots.test.ts.snap
+++ b/tests/js/__snapshots__/snapshots.test.ts.snap
@@ -8,10 +8,17 @@ exports[`AnswerPanel snapshot > renders an answer with citations 1`] = `
     <div class="mt-6 pt-4 border-t border-border">
       <p class="text-sm font-medium text-ink-muted mb-2">Sources</p>
       <div class="space-y-2">
-        <div id="citation-1" class="border border-border rounded bg-surface overflow-hidden"><button type="button" class="w-full flex items-start gap-2 text-left p-3 hover:bg-surface-raised transition-colors" aria-expanded="false" aria-controls="citation-1-body"><span class="text-primary font-medium shrink-0">[1]</span><span class="font-medium text-ink flex-1 min-w-0 truncate">Doc A</span><span class="text-xs px-2 py-0.5 rounded-full shrink-0 bg-cultural-subtle text-cultural">Cultural</span><span class="text-xs text-ink-muted shrink-0">+</span></button>
+        <!--
+            \`index\` must match the token the LLM emits in the answer body
+            (\`QaService\` uses the DB item id there). Using \`idx + 1\` broke
+            alignment whenever the LLM did not cite item #1 (giiken#93):
+            a body \`[2]\` pointed at Sources card \`#citation-1\` after the
+            list was trimmed to only-cited-items.
+          -->
+        <div id="citation-10" class="border border-border rounded bg-surface overflow-hidden"><button type="button" class="w-full flex items-start gap-2 text-left p-3 hover:bg-surface-raised transition-colors" aria-expanded="false" aria-controls="citation-10-body"><span class="text-primary font-medium shrink-0">[10]</span><span class="font-medium text-ink flex-1 min-w-0 truncate">Doc A</span><span class="text-xs px-2 py-0.5 rounded-full shrink-0 bg-cultural-subtle text-cultural">Cultural</span><span class="text-xs text-ink-muted shrink-0">+</span></button>
           <!--v-if-->
         </div>
-        <div id="citation-2" class="border border-border rounded bg-surface overflow-hidden"><button type="button" class="w-full flex items-start gap-2 text-left p-3 hover:bg-surface-raised transition-colors" aria-expanded="false" aria-controls="citation-2-body"><span class="text-primary font-medium shrink-0">[2]</span><span class="font-medium text-ink flex-1 min-w-0 truncate">Doc B</span><span class="text-xs px-2 py-0.5 rounded-full shrink-0 bg-land-subtle text-land">Land</span><span class="text-xs text-ink-muted shrink-0">+</span></button>
+        <div id="citation-11" class="border border-border rounded bg-surface overflow-hidden"><button type="button" class="w-full flex items-start gap-2 text-left p-3 hover:bg-surface-raised transition-colors" aria-expanded="false" aria-controls="citation-11-body"><span class="text-primary font-medium shrink-0">[11]</span><span class="font-medium text-ink flex-1 min-w-0 truncate">Doc B</span><span class="text-xs px-2 py-0.5 rounded-full shrink-0 bg-land-subtle text-land">Land</span><span class="text-xs text-ink-muted shrink-0">+</span></button>
           <!--v-if-->
         </div>
       </div>


### PR DESCRIPTION
## Summary
- \`CitationCard\` now accepts \`index: number | string\` and \`AnswerPanel\` passes \`citation.itemId\` instead of \`idx + 1\`. Both display label and anchor id match whatever token the LLM emitted in the answer body (DB item id, per \`QaService::SYSTEM_PROMPT\`).
- \`AnswerPanel.test.ts\` now asserts the alignment explicitly (acceptance criterion): hrefs in \`<sup>\` match \`#citation-<itemId>\` on the Sources card, and the visible label reuses the same token rather than a re-sequenced \`[1]\`.
- Ask snapshot regenerated to reflect itemId-based labels.

Closes #93

## Test plan
- [x] \`npm run test:js\` — 37/37 green (was 36, +1 alignment assertion)